### PR TITLE
Order 도메인 엔티티 생성, 도메인 엔티티 생성 팩토리 메서드 추가

### DIFF
--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -1,0 +1,69 @@
+package com.smore.order.domain.model;
+
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.domain.vo.Address;
+import com.smore.order.domain.vo.Product;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+
+    private UUID id;
+    private Long userId;
+    private Product product;
+    private Integer quantity;
+    private Integer totalAmount;
+    private Integer refundAmount;
+    private Integer feeAmount;
+    private UUID idempotencyKey;
+    private OrderStatus orderStatus;
+    private CancelState cancelState;
+    private LocalDateTime orderedAt;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private Address address;
+
+    public static Order create(
+        Long userId, UUID productId,
+        Integer productPrice, Integer quantity,
+        UUID idempotencyKey, LocalDateTime now,
+        String street, String city, String zipcode
+    ) {
+
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        if (userId == null) throw new IllegalArgumentException("유저 식별자는 필수값입니다.");
+        if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
+        if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
+        if (now == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
+
+        Integer totalAmount = calculateTotalPrice(productPrice, quantity);
+
+        return Order.builder()
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(OrderStatus.CRATED)
+            .cancelState(CancelState.NONE)
+            .orderedAt(now)
+            .address(address)
+            .build();
+    }
+
+    private static Integer calculateTotalPrice(Integer price, Integer quantity) {
+        return price * quantity;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/CancelState.java
+++ b/order/src/main/java/com/smore/order/domain/status/CancelState.java
@@ -1,0 +1,14 @@
+package com.smore.order.domain.status;
+
+public enum CancelState {
+    NONE("주문"),
+    CANCEL_REQUESTED("주문 취소 요청"),
+    CANCELLED("주문 취소 완료")
+    ;
+
+    private final String description;
+
+    CancelState(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
+++ b/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
@@ -1,0 +1,15 @@
+package com.smore.order.domain.status;
+
+public enum OrderStatus {
+    CRATED("주문 생성"),
+    COMPLETED("주문 완료"),
+    FAILED("주문 실패"),
+    CANCELLED("주문 취소")
+    ;
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/vo/Address.java
+++ b/order/src/main/java/com/smore/order/domain/vo/Address.java
@@ -1,0 +1,19 @@
+package com.smore.order.domain.vo;
+
+public record Address(
+    String street,
+    String city,
+    String zipcode
+) {
+    public Address {
+        if (street == null || street.isBlank()) {
+            throw new IllegalArgumentException("도로 명 주소 필수 입력");
+        }
+        if (city == null || city.isBlank()) {
+            throw new IllegalArgumentException("지번 주소 필수 입력");
+        }
+        if (zipcode == null || zipcode.isBlank()) {
+            throw new IllegalArgumentException("우편 번호 필수 입력");
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/vo/Product.java
+++ b/order/src/main/java/com/smore/order/domain/vo/Product.java
@@ -1,0 +1,14 @@
+package com.smore.order.domain.vo;
+
+import java.util.UUID;
+
+public record Product(
+    UUID productId,
+    Integer productPrice
+) {
+    public Product {
+        if (productId == null) throw new IllegalArgumentException("productId는 필수값입니다.");
+        if (productPrice == null) throw new IllegalArgumentException("상품 가격은 필수값입니다.");
+        if (productPrice < 0) throw new IllegalArgumentException("상품 가격은 음수일 수 없습니다.");
+    }
+}

--- a/order/src/test/java/com/smore/order/domain/model/OrderTest.java
+++ b/order/src/test/java/com/smore/order/domain/model/OrderTest.java
@@ -1,0 +1,452 @@
+package com.smore.order.domain.model;
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OrderTest {
+
+    @DisplayName("주문을 생성할 때 userId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenUserIdIsNull() {
+        // given
+        Long userId = null;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("유저 식별자는 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductIdIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = null;
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("productId는 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductPriceIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = null;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("상품 가격은 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productPrice가 음수일 수 없습니다. IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductPriceIsNegativeNumber() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = -1;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("상품 가격은 음수일 수 없습니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 street 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenStreetIsNull(String street) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("도로 명 주소 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 city 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenCityIsNull(String city) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("지번 주소 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 city 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenZipcodeIsNull(String zipcode) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("우편 번호 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주문 수량이 null인 경우  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @NullSource
+    void createOrderFailWhenQuantityIsNull(Integer quantity) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("주문 수량은 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 주문 수량이 0 이하인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void createOrderFailInvalidQuantity(Integer quantity) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("주문 수량은 1개 이상이어야 합니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 멱등키가 null이라면  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenIdempotencyKeyIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = null;
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("멱등키는 필수입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 멱등키가 null이라면  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenNowIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = null;
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("현재 날짜는 필수입니다.");
+    }
+
+    @DisplayName("주문이 정상적으로 생성되었는지 테스트")
+    @Test
+    void createOrder() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Order order = Order.create(
+            userId,
+            productId,
+            productPrice,
+            quantity,
+            idempotencyKey,
+            now,
+            street,
+            city,
+            zipcode
+        );
+
+        // then
+        Assertions.assertThat(order).isNotNull();
+        Assertions.assertThat(order.getUserId()).isEqualTo(userId);
+
+        Assertions.assertThat(order.getProduct()).isNotNull();
+        Assertions.assertThat(order.getProduct().productId()).isEqualTo(productId);
+        Assertions.assertThat(order.getProduct().productPrice()).isEqualTo(productPrice);
+
+        Assertions.assertThat(order.getQuantity()).isEqualTo(quantity);
+        Assertions.assertThat(order.getTotalAmount()).isEqualTo(productPrice * quantity);
+
+        Assertions.assertThat(order.getIdempotencyKey()).isEqualTo(idempotencyKey);
+        Assertions.assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CRATED);
+        Assertions.assertThat(order.getCancelState()).isEqualTo(CancelState.NONE);
+
+        Assertions.assertThat(order.getOrderedAt()).isEqualTo(now);
+
+        Assertions.assertThat(order.getAddress()).isNotNull();
+        Assertions.assertThat(order.getAddress().street()).isEqualTo(street);
+        Assertions.assertThat(order.getAddress().city()).isEqualTo(city);
+        Assertions.assertThat(order.getAddress().zipcode()).isEqualTo(zipcode);
+
+        Assertions.assertThat(order.getId()).isNull();
+        Assertions.assertThat(order.getRefundAmount()).isNull();
+        Assertions.assertThat(order.getFeeAmount()).isNull();
+        Assertions.assertThat(order.getConfirmedAt()).isNull();
+        Assertions.assertThat(order.getCancelledAt()).isNull();
+
+    }
+
+}


### PR DESCRIPTION
### 추가된 내용 
- 주문 도메인 추가 
  - `id` - 주문 식별자
  - `userId` - 주문자 식별자 
  - `product` - 상품 정보 VO (`productId`, `productPrice`로 구성)
  - `quantity` - 주문 수량 
  - `totalAmount` - 총 주문 가격 
  - `refundAmount` - 환불 금액 
  - `feeAmount` - 수수료 금액
  - `orderStatus` - 주문 상태
  - `cancelStatus` - 취소 상태
  - `orderedAt` - 주문 생성 시간 
  - `confirmedAt` - 주문 완료 시간
  - `cancelledAt` - 주문 취소 시간 
  - `Address` - 주문 주소 VO (`street`, `citry`, `zipcode`) 

- 주문 생성 팩토리 메서드 테스트 코드 추가 
  - 예외가 제대로 동작하는지 체크 
  - 주문이 생성되었을 때, 잘 생성되었는지 확인
 
