### PR TITLE
주문 영속성 엔티티 OrderEntity 추가

### DIFF
--- a/order/src/main/java/com/smore/order/OrderApplication.java
+++ b/order/src/main/java/com/smore/order/OrderApplication.java
@@ -2,7 +2,9 @@ package com.smore.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OrderApplication {
 

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -1,0 +1,69 @@
+package com.smore.order.domain.model;
+
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.domain.vo.Address;
+import com.smore.order.domain.vo.Product;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+
+    private UUID id;
+    private Long userId;
+    private Product product;
+    private Integer quantity;
+    private Integer totalAmount;
+    private Integer refundAmount;
+    private Integer feeAmount;
+    private UUID idempotencyKey;
+    private OrderStatus orderStatus;
+    private CancelState cancelState;
+    private LocalDateTime orderedAt;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private Address address;
+
+    public static Order create(
+        Long userId, UUID productId,
+        Integer productPrice, Integer quantity,
+        UUID idempotencyKey, LocalDateTime now,
+        String street, String city, String zipcode
+    ) {
+
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        if (userId == null) throw new IllegalArgumentException("유저 식별자는 필수값입니다.");
+        if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
+        if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
+        if (now == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
+
+        Integer totalAmount = calculateTotalPrice(productPrice, quantity);
+
+        return Order.builder()
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(OrderStatus.CRATED)
+            .cancelState(CancelState.NONE)
+            .orderedAt(now)
+            .address(address)
+            .build();
+    }
+
+    private static Integer calculateTotalPrice(Integer price, Integer quantity) {
+        return price * quantity;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -63,6 +63,47 @@ public class Order {
             .build();
     }
 
+    public static Order of(
+        UUID id,
+        Long userId,
+        UUID productId,
+        Integer productPrice,
+        Integer quantity,
+        Integer totalAmount,
+        Integer refundAmount,
+        Integer feeAmount,
+        UUID idempotencyKey,
+        OrderStatus orderStatus,
+        CancelState cancelState,
+        LocalDateTime orderedAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt,
+        String street,
+        String city,
+        String zipcode
+    ) {
+
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        return Order.builder()
+            .id(id)
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .refundAmount(refundAmount)
+            .feeAmount(feeAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(orderStatus)
+            .cancelState(cancelState)
+            .orderedAt(orderedAt)
+            .confirmedAt(confirmedAt)
+            .cancelledAt(cancelledAt)
+            .address(address)
+            .build();
+    }
+
     private static Integer calculateTotalPrice(Integer price, Integer quantity) {
         return price * quantity;
     }

--- a/order/src/main/java/com/smore/order/domain/status/CancelState.java
+++ b/order/src/main/java/com/smore/order/domain/status/CancelState.java
@@ -1,0 +1,14 @@
+package com.smore.order.domain.status;
+
+public enum CancelState {
+    NONE("주문"),
+    CANCEL_REQUESTED("주문 취소 요청"),
+    CANCELLED("주문 취소 완료")
+    ;
+
+    private final String description;
+
+    CancelState(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
+++ b/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
@@ -1,0 +1,15 @@
+package com.smore.order.domain.status;
+
+public enum OrderStatus {
+    CRATED("주문 생성"),
+    COMPLETED("주문 완료"),
+    FAILED("주문 실패"),
+    CANCELLED("주문 취소")
+    ;
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/vo/Address.java
+++ b/order/src/main/java/com/smore/order/domain/vo/Address.java
@@ -1,0 +1,19 @@
+package com.smore.order.domain.vo;
+
+public record Address(
+    String street,
+    String city,
+    String zipcode
+) {
+    public Address {
+        if (street == null || street.isBlank()) {
+            throw new IllegalArgumentException("도로 명 주소 필수 입력");
+        }
+        if (city == null || city.isBlank()) {
+            throw new IllegalArgumentException("지번 주소 필수 입력");
+        }
+        if (zipcode == null || zipcode.isBlank()) {
+            throw new IllegalArgumentException("우편 번호 필수 입력");
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/vo/Product.java
+++ b/order/src/main/java/com/smore/order/domain/vo/Product.java
@@ -1,0 +1,14 @@
+package com.smore.order.domain.vo;
+
+import java.util.UUID;
+
+public record Product(
+    UUID productId,
+    Integer productPrice
+) {
+    public Product {
+        if (productId == null) throw new IllegalArgumentException("productId는 필수값입니다.");
+        if (productPrice == null) throw new IllegalArgumentException("상품 가격은 필수값입니다.");
+        if (productPrice < 0) throw new IllegalArgumentException("상품 가격은 음수일 수 없습니다.");
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/BaseEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/BaseEntity.java
@@ -1,0 +1,39 @@
+package com.smore.order.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@FilterDef(
+    name = "softDeleteFilter",
+    defaultCondition = "deleted_at IS NULL",
+    autoEnabled = true,
+    applyToLoadByKey = true
+)
+@Filter(name = "softDeleteFilter")
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private Long deletedBy;
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Address.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Address.java
@@ -1,0 +1,32 @@
+package com.smore.order.infrastructure.persistence.entity.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+
+    @Column(name = "street", nullable = false)
+    private String street;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    @Column(name = "zipcode", nullable = false)
+    private String zipcode;
+
+    protected Address(String street, String city, String zipcode) {
+        if (street == null || street.isBlank()) throw new IllegalArgumentException("도로 명 주소 필수 입력");
+        if (city == null || city.isBlank()) throw new IllegalArgumentException("지번 주소 필수 입력");
+        if (zipcode == null || zipcode.isBlank()) throw new IllegalArgumentException("우편 번호 필수 입력");
+        this.street = street;
+        this.city = city;
+        this.zipcode = zipcode;
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
@@ -1,0 +1,112 @@
+package com.smore.order.infrastructure.persistence.entity.order;
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.infrastructure.persistence.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    name = "p_order",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_order_idempotency_key",
+        columnNames = {"idempotency_key"}
+    )
+)
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderEntity extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Embedded
+    private Product product;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "total_amount", nullable = false)
+    private Integer totalAmount;
+
+    @Column(name = "refund_amount")
+    private Integer refundAmount;
+
+    @Column(name = "fee_amount")
+    private Integer feeAmount;
+
+    @Column(name = "idempotency_key", nullable = false)
+    private UUID idempotencyKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status", nullable = false)
+    private OrderStatus orderStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cancel_status", nullable = false)
+    private CancelState cancelState;
+
+    @Column(name = "ordered_at", nullable = false)
+    private LocalDateTime orderedAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Embedded
+    private Address address;
+
+    public static OrderEntity create(
+        Long userId,
+        UUID productId, Integer productPrice, Integer quantity, Integer totalAmount,
+        UUID idempotencyKey, OrderStatus orderStatus, CancelState cancelState,
+        LocalDateTime orderedAt,
+        String street, String city, String zipcode
+    ) {
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        if (userId == null) throw new IllegalArgumentException("유저 식별자는 필수값입니다.");
+        if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
+        if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
+        if (orderStatus == OrderStatus.CRATED) throw new IllegalArgumentException("주문 생성 시 OrderStatus의 상태는 CREATED 상태여야 합니다.");
+        if (cancelState == CancelState.NONE) throw new IllegalArgumentException("주문 생성 시 CancelStatus의 상태는 NONE 상태여야 합니다.");
+        if (orderedAt == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
+
+        return OrderEntity.builder()
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(orderStatus)
+            .cancelState(cancelState)
+            .orderedAt(orderedAt)
+            .address(address)
+            .build();
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Product.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Product.java
@@ -1,0 +1,30 @@
+package com.smore.order.infrastructure.persistence.entity.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Column(name = "product_price", nullable = false)
+    private Integer productPrice;
+
+    protected Product(UUID productId, Integer productPrice) {
+        if (productId == null) throw new IllegalArgumentException("상품의 아이디는 필수입니다.");
+        if (productPrice == null) throw new IllegalArgumentException("상품 가격은 필수값입니다.");
+        if (productPrice < 0) throw new IllegalArgumentException("상품 가격은 음수일 수 없습니다.");
+        this.productId = productId;
+        this.productPrice = productPrice;
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OrderMapper.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OrderMapper.java
@@ -1,0 +1,59 @@
+package com.smore.order.infrastructure.persistence.mapper;
+
+
+import com.smore.order.domain.model.Order;
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+
+public final class OrderMapper {
+
+    private OrderMapper() {
+
+    }
+
+    public static OrderEntity toEntityForCreate(Order order) {
+        if (order == null) {
+            return null;
+        }
+
+        return OrderEntity.create(
+            order.getUserId(),
+            order.getProduct().productId(),
+            order.getProduct().productPrice(),
+            order.getQuantity(),
+            order.getTotalAmount(),
+            order.getIdempotencyKey(),
+            order.getOrderStatus(),
+            order.getCancelState(),
+            order.getOrderedAt(),
+            order.getAddress().street(),
+            order.getAddress().city(),
+            order.getAddress().zipcode()
+        );
+    }
+
+    public static Order toDomain(OrderEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return Order.of(
+            entity.getId(),
+            entity.getUserId(),
+            entity.getProduct().getProductId(),
+            entity.getProduct().getProductPrice(),
+            entity.getQuantity(),
+            entity.getTotalAmount(),
+            entity.getRefundAmount(),
+            entity.getFeeAmount(),
+            entity.getIdempotencyKey(),
+            entity.getOrderStatus(),
+            entity.getCancelState(),
+            entity.getOrderedAt(),
+            entity.getConfirmedAt(),
+            entity.getCancelledAt(),
+            entity.getAddress().getStreet(),
+            entity.getAddress().getCity(),
+            entity.getAddress().getZipcode()
+        );
+    }
+}

--- a/order/src/test/java/com/smore/order/domain/model/OrderTest.java
+++ b/order/src/test/java/com/smore/order/domain/model/OrderTest.java
@@ -1,0 +1,452 @@
+package com.smore.order.domain.model;
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OrderTest {
+
+    @DisplayName("주문을 생성할 때 userId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenUserIdIsNull() {
+        // given
+        Long userId = null;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("유저 식별자는 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductIdIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = null;
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("productId는 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductPriceIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = null;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("상품 가격은 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productPrice가 음수일 수 없습니다. IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductPriceIsNegativeNumber() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = -1;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("상품 가격은 음수일 수 없습니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 street 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenStreetIsNull(String street) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("도로 명 주소 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 city 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenCityIsNull(String city) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("지번 주소 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 city 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenZipcodeIsNull(String zipcode) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("우편 번호 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주문 수량이 null인 경우  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @NullSource
+    void createOrderFailWhenQuantityIsNull(Integer quantity) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("주문 수량은 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 주문 수량이 0 이하인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void createOrderFailInvalidQuantity(Integer quantity) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("주문 수량은 1개 이상이어야 합니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 멱등키가 null이라면  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenIdempotencyKeyIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = null;
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("멱등키는 필수입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 멱등키가 null이라면  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenNowIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = null;
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("현재 날짜는 필수입니다.");
+    }
+
+    @DisplayName("주문이 정상적으로 생성되었는지 테스트")
+    @Test
+    void createOrder() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Order order = Order.create(
+            userId,
+            productId,
+            productPrice,
+            quantity,
+            idempotencyKey,
+            now,
+            street,
+            city,
+            zipcode
+        );
+
+        // then
+        Assertions.assertThat(order).isNotNull();
+        Assertions.assertThat(order.getUserId()).isEqualTo(userId);
+
+        Assertions.assertThat(order.getProduct()).isNotNull();
+        Assertions.assertThat(order.getProduct().productId()).isEqualTo(productId);
+        Assertions.assertThat(order.getProduct().productPrice()).isEqualTo(productPrice);
+
+        Assertions.assertThat(order.getQuantity()).isEqualTo(quantity);
+        Assertions.assertThat(order.getTotalAmount()).isEqualTo(productPrice * quantity);
+
+        Assertions.assertThat(order.getIdempotencyKey()).isEqualTo(idempotencyKey);
+        Assertions.assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CRATED);
+        Assertions.assertThat(order.getCancelState()).isEqualTo(CancelState.NONE);
+
+        Assertions.assertThat(order.getOrderedAt()).isEqualTo(now);
+
+        Assertions.assertThat(order.getAddress()).isNotNull();
+        Assertions.assertThat(order.getAddress().street()).isEqualTo(street);
+        Assertions.assertThat(order.getAddress().city()).isEqualTo(city);
+        Assertions.assertThat(order.getAddress().zipcode()).isEqualTo(zipcode);
+
+        Assertions.assertThat(order.getId()).isNull();
+        Assertions.assertThat(order.getRefundAmount()).isNull();
+        Assertions.assertThat(order.getFeeAmount()).isNull();
+        Assertions.assertThat(order.getConfirmedAt()).isNull();
+        Assertions.assertThat(order.getCancelledAt()).isNull();
+
+    }
+
+}


### PR DESCRIPTION
### 추가된 내용 
- 영속성 엔티티 `OrderEntity` 추가 
- `BaseEntity` 추가 (`createdAt`, `updatedAt`, `DeletedAt`, `DeletedBy`)
- 주문 도메인 엔티티에 `of()` 메서드 추가
- 주문 도메인 엔티티와 영속성 엔티티 사이의 `Mapper` 클래스 추가 