### PR TITLE
feat: member/create 4계층 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ bin/
 /docker/redis/
 /docker/db/mongo/
 /docker/db/redis/
+/org/instancio/settings/Keys.class

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.0")
+    set('testcontainersVersion', "1.20.4")
 }
 
 dependencies {
@@ -64,7 +65,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.instancio:instancio-junit:5.5.1'
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'io.rest-assured:json-path:5.5.0'
@@ -77,6 +80,7 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+        mavenBom "org.testcontainers:testcontainers-bom:${testcontainersVersion}"
     }
 }
 

--- a/member/src/main/java/com/smore/member/application/service/AuthService.java
+++ b/member/src/main/java/com/smore/member/application/service/AuthService.java
@@ -1,0 +1,5 @@
+package com.smore.member.application.service;
+
+public interface AuthService {
+
+}

--- a/member/src/main/java/com/smore/member/application/service/RoleBasedMemberService.java
+++ b/member/src/main/java/com/smore/member/application/service/RoleBasedMemberService.java
@@ -1,0 +1,21 @@
+package com.smore.member.application.service;
+
+import com.smore.member.application.service.command.CreateCommand;
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.application.service.usecase.MemberCreate;
+import com.smore.member.application.service.usecase.MemberRead;
+import com.smore.member.application.service.usecase.RoleSupportable;
+
+public interface RoleBasedMemberService
+extends RoleSupportable, MemberCreate, MemberRead {
+
+    @Override
+    default MemberResult createMember(CreateCommand command) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    default MemberResult readMember() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/member/src/main/java/com/smore/member/application/service/command/CreateCommand.java
+++ b/member/src/main/java/com/smore/member/application/service/command/CreateCommand.java
@@ -1,0 +1,14 @@
+package com.smore.member.application.service.command;
+
+import com.smore.member.domain.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreateCommand {
+    final Role role;
+    final String email;
+    final String password;
+    final String nickname;
+}

--- a/member/src/main/java/com/smore/member/application/service/impl/AbstractMemberService.java
+++ b/member/src/main/java/com/smore/member/application/service/impl/AbstractMemberService.java
@@ -1,16 +1,16 @@
 package com.smore.member.application.service.impl;
 
 import com.smore.member.application.service.RoleBasedMemberService;
-import com.smore.member.application.service.mapper.MemberMapper;
+import com.smore.member.application.service.mapper.MemberAppMapper;
 import com.smore.member.domain.repository.MemberRepository;
 
 public abstract class AbstractMemberService implements RoleBasedMemberService {
 
     protected final MemberRepository memberRepository;
-    protected final MemberMapper mapper;
+    protected final MemberAppMapper mapper;
 
     protected AbstractMemberService(MemberRepository memberRepository
-    , MemberMapper mapper) {
+    , MemberAppMapper mapper) {
         this.memberRepository = memberRepository;
         this.mapper = mapper;
     }

--- a/member/src/main/java/com/smore/member/application/service/impl/AbstractMemberService.java
+++ b/member/src/main/java/com/smore/member/application/service/impl/AbstractMemberService.java
@@ -1,0 +1,18 @@
+package com.smore.member.application.service.impl;
+
+import com.smore.member.application.service.RoleBasedMemberService;
+import com.smore.member.application.service.mapper.MemberMapper;
+import com.smore.member.domain.repository.MemberRepository;
+
+public abstract class AbstractMemberService implements RoleBasedMemberService {
+
+    protected final MemberRepository memberRepository;
+    protected final MemberMapper mapper;
+
+    protected AbstractMemberService(MemberRepository memberRepository
+    , MemberMapper mapper) {
+        this.memberRepository = memberRepository;
+        this.mapper = mapper;
+    }
+
+}

--- a/member/src/main/java/com/smore/member/application/service/impl/NoneMemberServiceImpl.java
+++ b/member/src/main/java/com/smore/member/application/service/impl/NoneMemberServiceImpl.java
@@ -1,0 +1,45 @@
+package com.smore.member.application.service.impl;
+
+import com.smore.member.application.service.command.CreateCommand;
+import com.smore.member.application.service.mapper.MemberMapper;
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.domain.enums.Role;
+import com.smore.member.domain.model.Member;
+import com.smore.member.domain.repository.MemberRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NoneMemberServiceImpl extends AbstractMemberService {
+
+    private final PasswordEncoder passwordEncoder;
+
+    public NoneMemberServiceImpl(
+        MemberRepository memberRepository,
+        MemberMapper mapper,
+        PasswordEncoder passwordEncoder
+    ) {
+        super(memberRepository, mapper);
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Role getSupportedRole() {
+        return Role.NONE;
+    }
+
+    @Override
+    public MemberResult createMember(CreateCommand command) {
+
+        Member member = Member.create(
+            command.getRole(),
+            command.getEmail(),
+            passwordEncoder.encode(command.getPassword()),
+            command.getNickname()
+        );
+
+        Member savedMember = memberRepository.save(member);
+
+        return mapper.toMemberResult(savedMember);
+    }
+}

--- a/member/src/main/java/com/smore/member/application/service/impl/NoneMemberServiceImpl.java
+++ b/member/src/main/java/com/smore/member/application/service/impl/NoneMemberServiceImpl.java
@@ -1,7 +1,7 @@
 package com.smore.member.application.service.impl;
 
 import com.smore.member.application.service.command.CreateCommand;
-import com.smore.member.application.service.mapper.MemberMapper;
+import com.smore.member.application.service.mapper.MemberAppMapper;
 import com.smore.member.application.service.result.MemberResult;
 import com.smore.member.domain.enums.Role;
 import com.smore.member.domain.model.Member;
@@ -16,7 +16,7 @@ public class NoneMemberServiceImpl extends AbstractMemberService {
 
     public NoneMemberServiceImpl(
         MemberRepository memberRepository,
-        MemberMapper mapper,
+        MemberAppMapper mapper,
         PasswordEncoder passwordEncoder
     ) {
         super(memberRepository, mapper);

--- a/member/src/main/java/com/smore/member/application/service/mapper/MemberAppMapper.java
+++ b/member/src/main/java/com/smore/member/application/service/mapper/MemberAppMapper.java
@@ -5,7 +5,7 @@ import com.smore.member.domain.model.Member;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MemberMapper {
+public class MemberAppMapper {
 
     public MemberResult toMemberResult(Member member) {
         return new MemberResult(

--- a/member/src/main/java/com/smore/member/application/service/mapper/MemberMapper.java
+++ b/member/src/main/java/com/smore/member/application/service/mapper/MemberMapper.java
@@ -1,0 +1,22 @@
+package com.smore.member.application.service.mapper;
+
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.domain.model.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberMapper {
+
+    public MemberResult toMemberResult(Member member) {
+        return new MemberResult(
+            member.getId(),
+            member.getRole(),
+            member.getCredential().email(),
+            member.getNickname(),
+            member.getAuctionCancelCount(),
+            member.getStatus(),
+            member.getDeletedBy()
+        );
+    }
+
+}

--- a/member/src/main/java/com/smore/member/application/service/result/MemberResult.java
+++ b/member/src/main/java/com/smore/member/application/service/result/MemberResult.java
@@ -1,0 +1,15 @@
+package com.smore.member.application.service.result;
+
+import com.smore.member.domain.enums.MemberStatus;
+import com.smore.member.domain.enums.Role;
+
+public record MemberResult(
+    Long id,
+    Role role,
+    String email,
+    String nickname,
+    Integer auctionCancelCount,
+    MemberStatus memberStatus,
+    Long deletedBy
+) {
+}

--- a/member/src/main/java/com/smore/member/application/service/selector/MemberServiceSelector.java
+++ b/member/src/main/java/com/smore/member/application/service/selector/MemberServiceSelector.java
@@ -1,0 +1,24 @@
+package com.smore.member.application.service.selector;
+
+import com.smore.member.application.service.RoleBasedMemberService;
+import com.smore.member.domain.enums.Role;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberServiceSelector {
+
+    private final Map<Role, RoleBasedMemberService> serviceMap = new EnumMap<>(Role.class);
+
+    public MemberServiceSelector(List<RoleBasedMemberService> services) {
+        for (RoleBasedMemberService service : services) {
+            serviceMap.put(service.getSupportedRole(), service);
+        }
+    }
+
+    public RoleBasedMemberService select(Role role) {
+        return serviceMap.get(role);
+    }
+}

--- a/member/src/main/java/com/smore/member/application/service/usecase/MemberCreate.java
+++ b/member/src/main/java/com/smore/member/application/service/usecase/MemberCreate.java
@@ -1,0 +1,10 @@
+package com.smore.member.application.service.usecase;
+
+import com.smore.member.application.service.command.CreateCommand;
+import com.smore.member.application.service.result.MemberResult;
+
+public interface MemberCreate {
+
+    MemberResult createMember(CreateCommand command);
+
+}

--- a/member/src/main/java/com/smore/member/application/service/usecase/MemberRead.java
+++ b/member/src/main/java/com/smore/member/application/service/usecase/MemberRead.java
@@ -1,0 +1,9 @@
+package com.smore.member.application.service.usecase;
+
+import com.smore.member.application.service.result.MemberResult;
+
+public interface MemberRead {
+
+    MemberResult readMember();
+
+}

--- a/member/src/main/java/com/smore/member/application/service/usecase/RoleSupportable.java
+++ b/member/src/main/java/com/smore/member/application/service/usecase/RoleSupportable.java
@@ -1,0 +1,9 @@
+package com.smore.member.application.service.usecase;
+
+import com.smore.member.domain.enums.Role;
+
+public interface RoleSupportable {
+
+    Role getSupportedRole();
+
+}

--- a/member/src/main/java/com/smore/member/domain/enums/MemberStatus.java
+++ b/member/src/main/java/com/smore/member/domain/enums/MemberStatus.java
@@ -1,8 +1,18 @@
 package com.smore.member.domain.enums;
 
 public enum MemberStatus {
-    ACTIVE,
-    INACTIVE,
-    DELETED,
-    BANNED
+    ACTIVE("활성 계정"),
+    INACTIVE("비활성 계정"),
+    DELETED("삭제된 계정"),
+    BANNED("정지된 계정");
+
+    private final String desc;
+
+    MemberStatus(String desc) {
+        this.desc = desc;
+    }
+
+    public String desc() {
+        return desc;
+    }
 }

--- a/member/src/main/java/com/smore/member/domain/enums/MemberStatus.java
+++ b/member/src/main/java/com/smore/member/domain/enums/MemberStatus.java
@@ -1,6 +1,6 @@
 package com.smore.member.domain.enums;
 
-public enum Status {
+public enum MemberStatus {
     ACTIVE,
     INACTIVE,
     DELETED,

--- a/member/src/main/java/com/smore/member/domain/enums/RegistrationStatus.java
+++ b/member/src/main/java/com/smore/member/domain/enums/RegistrationStatus.java
@@ -1,6 +1,0 @@
-package com.smore.member.domain.enums;
-
-public enum RegistrationStatus {
-    REGISTERED,
-    UNREGISTERED,
-}

--- a/member/src/main/java/com/smore/member/domain/enums/Role.java
+++ b/member/src/main/java/com/smore/member/domain/enums/Role.java
@@ -1,7 +1,17 @@
 package com.smore.member.domain.enums;
 
 public enum Role {
-    ADMIN,
-    SELLER,
-    CONSUMER
+    ADMIN("관리자"),
+    SELLER("판매자"),
+    CONSUMER("소비자");
+
+    private final String desc;
+
+    Role(String desc) {
+        this.desc = desc;
+    }
+
+    public String desc() {
+        return desc;
+    }
 }

--- a/member/src/main/java/com/smore/member/domain/enums/Role.java
+++ b/member/src/main/java/com/smore/member/domain/enums/Role.java
@@ -1,6 +1,7 @@
 package com.smore.member.domain.enums;
 
 public enum Role {
+    NONE("비회원"),
     ADMIN("관리자"),
     SELLER("판매자"),
     CONSUMER("소비자");

--- a/member/src/main/java/com/smore/member/domain/model/Member.java
+++ b/member/src/main/java/com/smore/member/domain/model/Member.java
@@ -3,6 +3,7 @@ package com.smore.member.domain.model;
 import com.smore.member.domain.enums.MemberStatus;
 import com.smore.member.domain.enums.Role;
 import com.smore.member.domain.vo.Credential;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,4 +22,24 @@ public class Member {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
     private Long deletedBy;
+
+    public static Member create(
+        Role role,
+        String email,
+        String password,
+        String nickname
+    ) {
+        return new Member(
+            null,
+            role,
+            new Credential(email, password),
+            nickname,
+            0,
+            MemberStatus.ACTIVE,
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            null,
+            null
+        );
+    }
 }

--- a/member/src/main/java/com/smore/member/domain/model/Member.java
+++ b/member/src/main/java/com/smore/member/domain/model/Member.java
@@ -3,7 +3,6 @@ package com.smore.member.domain.model;
 import com.smore.member.domain.enums.MemberStatus;
 import com.smore.member.domain.enums.Role;
 import com.smore.member.domain.vo.Credential;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/member/src/main/java/com/smore/member/domain/model/Member.java
+++ b/member/src/main/java/com/smore/member/domain/model/Member.java
@@ -1,8 +1,7 @@
 package com.smore.member.domain.model;
 
-import com.smore.member.domain.enums.RegistrationStatus;
+import com.smore.member.domain.enums.MemberStatus;
 import com.smore.member.domain.enums.Role;
-import com.smore.member.domain.enums.Status;
 import com.smore.member.domain.vo.Credential;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -16,10 +15,10 @@ public class Member {
     private Credential credential;
     private String nickname;
     private Integer auctionCancelCount;
-    private Status status;
-    private RegistrationStatus registrationStatus;
+    private MemberStatus status;
+
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
-    private Long deleteBy;
+    private Long deletedBy;
 }

--- a/member/src/main/java/com/smore/member/domain/repository/MemberRepository.java
+++ b/member/src/main/java/com/smore/member/domain/repository/MemberRepository.java
@@ -4,4 +4,6 @@ import com.smore.member.domain.model.Member;
 
 public interface MemberRepository {
     Member findByEmail(String email);
+
+    Member save(Member member);
 }

--- a/member/src/main/java/com/smore/member/infrastructure/persistance/MemberRepositoryImpl.java
+++ b/member/src/main/java/com/smore/member/infrastructure/persistance/MemberRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.smore.member.infrastructure.persistance;
 
 import com.smore.member.domain.model.Member;
 import com.smore.member.domain.repository.MemberRepository;
+import com.smore.member.infrastructure.persistance.jpa.entity.MemberJpa;
+import com.smore.member.infrastructure.persistance.jpa.mapper.MemberJpaMapper;
 import com.smore.member.infrastructure.persistance.jpa.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,10 +12,20 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class MemberRepositoryImpl implements MemberRepository {
 
+    private final MemberJpaMapper mapper;
     private final MemberJpaRepository memberJpaRepository;
 
     @Override
     public Member findByEmail(String email) {
-        return null;
+        MemberJpa memberJpa = memberJpaRepository.findByCredentialEmail(email);
+
+        return memberJpa != null ? mapper.toDomain(memberJpa) : null;
+    }
+
+    @Override
+    public Member save(Member member) {
+        MemberJpa memberJpa = memberJpaRepository.save(mapper.toEntity(member));
+
+        return mapper.toDomain(memberJpa);
     }
 }

--- a/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/entity/MemberJpa.java
+++ b/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/entity/MemberJpa.java
@@ -1,8 +1,7 @@
 package com.smore.member.infrastructure.persistance.jpa.entity;
 
-import com.smore.member.domain.enums.RegistrationStatus;
 import com.smore.member.domain.enums.Role;
-import com.smore.member.domain.enums.Status;
+import com.smore.member.domain.enums.MemberStatus;
 import com.smore.member.infrastructure.persistance.jpa.vo.CredentialEmbeddable;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -19,7 +18,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "p_member")
@@ -41,12 +39,10 @@ public class MemberJpa {
     private String nickname;
     private Integer auctionCancelCount;
     @Enumerated(EnumType.STRING)
-    private Status status;
-    @Enumerated(EnumType.STRING)
-    private RegistrationStatus registrationStatus;
+    private MemberStatus status;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
-    private Long deleteBy;
+    private Long deletedBy;
 }

--- a/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/entity/MemberJpa.java
+++ b/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/entity/MemberJpa.java
@@ -16,12 +16,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "p_member")
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberJpa {

--- a/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/mapper/MemberJpaMapper.java
+++ b/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/mapper/MemberJpaMapper.java
@@ -7,7 +7,7 @@ import com.smore.member.infrastructure.persistance.jpa.vo.CredentialEmbeddable;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
-public interface MemberMapper {
+public interface MemberJpaMapper {
     Member toDomain(MemberJpa entity);
 
     MemberJpa toEntity(Member member);

--- a/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/repository/MemberJpaRepository.java
+++ b/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/repository/MemberJpaRepository.java
@@ -1,8 +1,9 @@
 package com.smore.member.infrastructure.persistance.jpa.repository;
 
-import com.smore.member.domain.model.Member;
+import com.smore.member.infrastructure.persistance.jpa.entity.MemberJpa;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+public interface MemberJpaRepository extends JpaRepository<MemberJpa, Long> {
 
+    MemberJpa findByCredentialEmail(String email);
 }

--- a/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/vo/CredentialEmbeddable.java
+++ b/member/src/main/java/com/smore/member/infrastructure/persistance/jpa/vo/CredentialEmbeddable.java
@@ -2,11 +2,14 @@ package com.smore.member.infrastructure.persistance.jpa.vo;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Embeddable
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CredentialEmbeddable {

--- a/member/src/main/java/com/smore/member/infrastructure/security/userdetails/CustomUserDetails.java
+++ b/member/src/main/java/com/smore/member/infrastructure/security/userdetails/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package com.smore.member.infrastructure.security.userdetails;
 
-import com.smore.member.domain.enums.Status;
+import com.smore.member.domain.enums.MemberStatus;
 import com.smore.member.domain.model.Member;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +43,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return member.getStatus() == Status.ACTIVE;
+        return member.getStatus() == MemberStatus.ACTIVE;
     }
 
     @Override

--- a/member/src/main/java/com/smore/member/presentation/web/MemberController.java
+++ b/member/src/main/java/com/smore/member/presentation/web/MemberController.java
@@ -1,0 +1,46 @@
+package com.smore.member.presentation.web;
+
+import com.smore.common.response.ApiResponse;
+import com.smore.common.response.CommonResponse;
+import com.smore.member.application.service.RoleBasedMemberService;
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.application.service.selector.MemberServiceSelector;
+import com.smore.member.domain.enums.Role;
+import com.smore.member.presentation.web.dto.request.CreateRequestDto;
+import com.smore.member.presentation.web.dto.response.CreateResponseDto;
+import com.smore.member.presentation.web.mapper.MemberControllerMapper;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberServiceSelector memberServiceSelector;
+    private final MemberControllerMapper mapper;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<CreateResponseDto>> registerConsumer(
+        @RequestHeader("X-User-Role") Role role,
+        @RequestBody CreateRequestDto requestDto
+    ) {
+        RoleBasedMemberService service
+            = memberServiceSelector.select(role);
+
+        MemberResult member = service.readMember();
+        var res = mapper.toCreateResponseDto(member);
+
+        URI uri = URI.create("/api/v1/members/" + res.id());
+
+        return ResponseEntity.created(uri)
+            .body(ApiResponse.ok(res));
+    }
+
+}

--- a/member/src/main/java/com/smore/member/presentation/web/MemberController.java
+++ b/member/src/main/java/com/smore/member/presentation/web/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
         RoleBasedMemberService service
             = memberServiceSelector.select(role);
 
-        MemberResult member = service.readMember();
+        MemberResult member = service.createMember(mapper.toCreateCommand(requestDto));
         var res = mapper.toCreateResponseDto(member);
 
         URI uri = URI.create("/api/v1/members/" + res.id());

--- a/member/src/main/java/com/smore/member/presentation/web/dto/request/CreateRequestDto.java
+++ b/member/src/main/java/com/smore/member/presentation/web/dto/request/CreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.smore.member.presentation.web.dto.request;
+
+import com.smore.member.domain.enums.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateRequestDto(
+    @NotNull
+    Role role,
+    @NotBlank
+    @Email
+    String email,
+    @NotBlank
+    String password,
+    @NotBlank
+    String nickname
+) {
+
+}

--- a/member/src/main/java/com/smore/member/presentation/web/dto/response/CreateResponseDto.java
+++ b/member/src/main/java/com/smore/member/presentation/web/dto/response/CreateResponseDto.java
@@ -1,0 +1,9 @@
+package com.smore.member.presentation.web.dto.response;
+
+public record CreateResponseDto(
+    Long id,
+    String email,
+    String nickname
+) {
+
+}

--- a/member/src/main/java/com/smore/member/presentation/web/mapper/MemberControllerMapper.java
+++ b/member/src/main/java/com/smore/member/presentation/web/mapper/MemberControllerMapper.java
@@ -1,0 +1,28 @@
+package com.smore.member.presentation.web.mapper;
+
+import com.smore.member.application.service.command.CreateCommand;
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.presentation.web.dto.request.CreateRequestDto;
+import com.smore.member.presentation.web.dto.response.CreateResponseDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberControllerMapper {
+
+    public CreateCommand toCreateCommand(CreateRequestDto requestDto) {
+        return new CreateCommand(
+            requestDto.role(),
+            requestDto.email(),
+            requestDto.password(),
+            requestDto.nickname()
+        );
+    }
+
+    public CreateResponseDto toCreateResponseDto(MemberResult result) {
+        return new CreateResponseDto(
+            result.id(),
+            result.email(),
+            result.nickname()
+        );
+    }
+}

--- a/member/src/main/java/com/smore/seller/domain/enums/SellerStatus.java
+++ b/member/src/main/java/com/smore/seller/domain/enums/SellerStatus.java
@@ -1,8 +1,19 @@
 package com.smore.seller.domain.enums;
 
 public enum SellerStatus {
-    ACTIVE,
-    INACTIVE,
-    DELETED,
-    BANNED
+    PENDING("승인 대기"),
+    ACTIVE("활성 판매자"),
+    INACTIVE("비활성 판매자"),
+    DELETED("삭제된 판매자"),
+    BANNED("정지된 판매자");
+
+    private final String desc;
+
+    SellerStatus(String desc) {
+        this.desc = desc;
+    }
+
+    public String desc() {
+        return desc;
+    }
 }

--- a/member/src/main/java/com/smore/seller/domain/enums/SellerStatus.java
+++ b/member/src/main/java/com/smore/seller/domain/enums/SellerStatus.java
@@ -1,0 +1,8 @@
+package com.smore.seller.domain.enums;
+
+public enum SellerStatus {
+    ACTIVE,
+    INACTIVE,
+    DELETED,
+    BANNED
+}

--- a/member/src/main/java/com/smore/seller/domain/model/Seller.java
+++ b/member/src/main/java/com/smore/seller/domain/model/Seller.java
@@ -1,0 +1,21 @@
+package com.smore.seller.domain.model;
+
+import com.smore.seller.domain.enums.SellerStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Seller {
+    private final UUID id;
+    private final Long memberId;
+    private String accountNum;
+    private SellerStatus status;
+
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private Long deletedBy;
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/persistance/config/QuerydslConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistance/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.smore.seller.infrastructure.persistance.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/persistance/entity/SellerJpa.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistance/entity/SellerJpa.java
@@ -11,11 +11,13 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "p_seller")

--- a/member/src/main/java/com/smore/seller/infrastructure/persistance/entity/SellerJpa.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistance/entity/SellerJpa.java
@@ -1,0 +1,35 @@
+package com.smore.seller.infrastructure.persistance.entity;
+
+import com.smore.seller.domain.enums.SellerStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "p_seller")
+public class SellerJpa {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    private Long memberId;
+    private String accountNum;
+    @Enumerated(EnumType.STRING)
+    private SellerStatus status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private Long deletedBy;
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/swagger/SwaggerConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/swagger/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.smore.seller.infrastructure.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+            .info(new Info()
+                .title("Member Service API")
+                .description("JWT 기반 인증 포함 API 문서")
+                .version("1.0.0"))
+            .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+            .components(new Components()
+                .addSecuritySchemes(securitySchemeName,
+                    new SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")));
+    }
+}

--- a/member/src/main/resources/data.sql
+++ b/member/src/main/resources/data.sql
@@ -1,11 +1,22 @@
-INSERT INTO p_member (role, email, password, nickname, auction_cancel_count, status, registration_status, created_at, updated_at)
-VALUES ('ADMIN', 'admin@example.com', 'hashed-admin-password', 'Admin', 0, 'ACTIVE', 'REGISTERED', NOW(), NOW())
-ON CONFLICT (email) DO NOTHING;
+-- Seed members by role/status
+INSERT INTO p_member (id, role, email, password, nickname, auction_cancel_count, status, created_at, updated_at, deleted_at, deleted_by)
+VALUES
+    (1, 'ADMIN', 'admin@example.com', 'hashed-admin-password', 'admin', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
+    (2, 'SELLER', 'seller_pending@example.com', 'hashed-seller-password', 'seller_pending', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
+    (3, 'SELLER', 'seller_active@example.com', 'hashed-seller-password', 'seller_active', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
+    (4, 'SELLER', 'seller_inactive@example.com', 'hashed-seller-password', 'seller_inactive', 0, 'INACTIVE', NOW(), NOW(), NULL, NULL),
+    (5, 'SELLER', 'seller_deleted@example.com', 'hashed-seller-password', 'seller_deleted', 1, 'DELETED', NOW(), NOW(), NOW(), 1),
+    (6, 'SELLER', 'seller_banned@example.com', 'hashed-seller-password', 'seller_banned', 2, 'BANNED', NOW(), NOW(), NOW(), 1),
+    (7, 'CONSUMER', 'consumer_active@example.com', 'hashed-consumer-password', 'consumer_active', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
+    (8, 'CONSUMER', 'consumer_inactive@example.com', 'hashed-consumer-password', 'consumer_inactive', 0, 'INACTIVE', NOW(), NOW(), NULL, NULL)
+ON CONFLICT DO NOTHING;
 
-INSERT INTO p_member (role, email, password, nickname, auction_cancel_count, status, registration_status, created_at, updated_at)
-VALUES ('SELLER', 'seller@example.com', 'hashed-seller-password', 'Seller', 0, 'ACTIVE', 'REGISTERED', NOW(), NOW())
-ON CONFLICT (email) DO NOTHING;
-
-INSERT INTO p_member (role, email, password, nickname, auction_cancel_count, status, registration_status, created_at, updated_at)
-VALUES ('CONSUMER', 'consumer@example.com', 'hashed-consumer-password', 'Consumer', 0, 'ACTIVE', 'REGISTERED', NOW(), NOW())
-ON CONFLICT (email) DO NOTHING;
+-- Seed sellers by status (linked to seller members above)
+INSERT INTO p_seller (id, member_id, account_num, status, created_at, updated_at, deleted_at, deleted_by)
+VALUES
+    ('00000000-0000-0000-0000-000000000001', 2, '111-11-111111', 'PENDING', NOW(), NOW(), NULL, NULL),
+    ('00000000-0000-0000-0000-000000000002', 3, '222-22-222222', 'ACTIVE', NOW(), NOW(), NULL, NULL),
+    ('00000000-0000-0000-0000-000000000003', 4, '333-33-333333', 'INACTIVE', NOW(), NOW(), NULL, NULL),
+    ('00000000-0000-0000-0000-000000000004', 5, '444-44-444444', 'DELETED', NOW(), NOW(), NOW(), 1),
+    ('00000000-0000-0000-0000-000000000005', 6, '555-55-555555', 'BANNED', NOW(), NOW(), NOW(), 1)
+ON CONFLICT DO NOTHING;

--- a/member/src/test/java/com/smore/member/application/service/impl/NoneMemberServiceImplTest.java
+++ b/member/src/test/java/com/smore/member/application/service/impl/NoneMemberServiceImplTest.java
@@ -1,0 +1,77 @@
+package com.smore.member.application.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.smore.member.application.service.mapper.MemberAppMapper;
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.application.service.command.CreateCommand;
+import com.smore.member.domain.enums.Role;
+import com.smore.member.domain.model.Member;
+import com.smore.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class NoneMemberServiceImplTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    MemberAppMapper mapper;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    NoneMemberServiceImpl service;
+
+    @Test
+    void getSupportedRole() {
+        assertThat(service.getSupportedRole()).isEqualTo(Role.NONE);
+    }
+
+    @Test
+    void createMember_success() {
+        // given
+        CreateCommand command = new CreateCommand(
+            Role.CONSUMER,
+            "user@example.com",
+            "plain-pass",
+            "nickname"
+        );
+
+        Member saved = Member.create(
+            Role.CONSUMER,
+            command.getEmail(),
+            "encoded-pass",
+            command.getNickname()
+        );
+
+        MemberResult expectedResult = new MemberResult(
+            1L,
+            Role.CONSUMER,
+            command.getEmail(),
+            command.getNickname(),
+            0,
+            saved.getStatus(),
+            null
+        );
+
+        when(passwordEncoder.encode(command.getPassword())).thenReturn("encoded-pass");
+        when(memberRepository.save(any(Member.class))).thenReturn(saved);
+        when(mapper.toMemberResult(saved)).thenReturn(expectedResult);
+
+        // when
+        MemberResult result = service.createMember(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+    }
+}

--- a/member/src/test/java/com/smore/member/domain/MemberTest.java
+++ b/member/src/test/java/com/smore/member/domain/MemberTest.java
@@ -1,0 +1,50 @@
+package com.smore.member.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.smore.member.domain.enums.Role;
+import com.smore.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class MemberTest {
+
+    @Nested
+        @DisplayName("멤버 create 테스트")
+    class MemberCreate {
+        @Test
+        @DisplayName("id 는 null 이여야 한다")
+        void idNull() {
+            // given, when
+            Member member = Member.create(
+                Role.CONSUMER,
+                "consumer@naver.com",
+                "pw",
+                "소비자"
+            );
+
+            // then
+            assertAll(
+                () -> assertThat(member.getId()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("createdAt 은 존재해야한다")
+        void createdAt() {
+            Member member = Member.create(
+                Role.CONSUMER,
+                "consumer@naver.com",
+                "pw",
+                "소비자"
+            );
+
+            assertAll(
+                () -> assertThat(member.getCreatedAt()).isNotNull()
+            );
+        }
+    }
+
+}

--- a/member/src/test/java/com/smore/member/infrastructure/config/TestContainerConfig.java
+++ b/member/src/test/java/com/smore/member/infrastructure/config/TestContainerConfig.java
@@ -1,0 +1,18 @@
+package com.smore.member.infrastructure.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfig {
+
+    @Bean
+    @ServiceConnection
+    public PostgreSQLContainer<?> postgreSQLContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:18"));
+    }
+
+}

--- a/member/src/test/java/com/smore/member/infrastructure/persistance/MemberRepositoryImplTest.java
+++ b/member/src/test/java/com/smore/member/infrastructure/persistance/MemberRepositoryImplTest.java
@@ -1,0 +1,72 @@
+package com.smore.member.infrastructure.persistance;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.smore.member.domain.enums.Role;
+import com.smore.member.domain.model.Member;
+import com.smore.member.domain.repository.MemberRepository;
+import com.smore.member.domain.vo.Credential;
+import com.smore.member.infrastructure.config.TestContainerConfig;
+import com.smore.member.infrastructure.persistance.config.QuerydslConfig;
+import com.smore.member.infrastructure.persistance.jpa.mapper.MemberJpaMapperImpl;
+import java.time.LocalDateTime;
+import org.instancio.Instancio;
+import org.instancio.Select;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+    MemberJpaMapperImpl.class,
+    MemberRepositoryImpl.class,
+    QuerydslConfig.class,
+    TestContainerConfig.class
+})
+class MemberRepositoryImplTest {
+    private static final Logger log = LoggerFactory.getLogger(MemberRepositoryImplTest.class);
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        Settings nonNullSettings = Settings.create()
+            .set(Keys.STRING_NULLABLE, false);
+
+        Member member = Instancio.of(Member.class)
+            .withSettings(nonNullSettings)
+            .set(Select.field(Member.class, "id"), null)
+            .set(Select.field(Member.class, "role"), Role.CONSUMER)
+            .set(Select.field(Member.class, "createdAt"), LocalDateTime.now())
+            .set(Select.field(Member.class, "updatedAt"), LocalDateTime.now())
+            .supply(Select.all(Credential.class),
+                () -> new Credential("instancio@example.com", "password123!"))
+            .create();
+
+        memberRepository.save(member);
+    }
+
+    @Test
+    void findById() {
+        // when
+        Member findMember = memberRepository.findByEmail("instancio@example.com");
+
+        // then
+        assertAll(
+            () -> assertNotNull(findMember),
+            () -> assertNotNull(findMember.getId())
+        );
+    }
+}

--- a/member/src/test/java/com/smore/member/infrastructure/persistance/MemberRepositoryImplTest.java
+++ b/member/src/test/java/com/smore/member/infrastructure/persistance/MemberRepositoryImplTest.java
@@ -10,6 +10,7 @@ import com.smore.member.domain.vo.Credential;
 import com.smore.member.infrastructure.config.TestContainerConfig;
 import com.smore.member.infrastructure.persistance.config.QuerydslConfig;
 import com.smore.member.infrastructure.persistance.jpa.mapper.MemberJpaMapperImpl;
+import groovy.util.logging.Slf4j;
 import java.time.LocalDateTime;
 import org.instancio.Instancio;
 import org.instancio.Select;
@@ -17,8 +18,6 @@ import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -35,7 +34,6 @@ import org.springframework.test.context.ActiveProfiles;
     TestContainerConfig.class
 })
 class MemberRepositoryImplTest {
-    private static final Logger log = LoggerFactory.getLogger(MemberRepositoryImplTest.class);
 
     @Autowired
     private MemberRepository memberRepository;

--- a/member/src/test/java/com/smore/member/presentation/web/MemberControllerTest.java
+++ b/member/src/test/java/com/smore/member/presentation/web/MemberControllerTest.java
@@ -1,0 +1,92 @@
+package com.smore.member.presentation.web;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.member.application.service.RoleBasedMemberService;
+import com.smore.member.application.service.result.MemberResult;
+import com.smore.member.application.service.selector.MemberServiceSelector;
+import com.smore.member.domain.enums.MemberStatus;
+import com.smore.member.domain.enums.Role;
+import com.smore.member.presentation.web.dto.request.CreateRequestDto;
+import com.smore.member.presentation.web.dto.response.CreateResponseDto;
+import com.smore.member.presentation.web.mapper.MemberControllerMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    MemberServiceSelector memberServiceSelector;
+
+    @MockitoBean
+    MemberControllerMapper memberControllerMapper;
+
+    @MockitoBean
+    RoleBasedMemberService roleBasedMemberService;
+
+    @Test
+    @DisplayName("POST /api/v1/members - 201 Created with response body")
+    void registerConsumer() throws Exception {
+        // given
+        CreateRequestDto requestDto = new CreateRequestDto(
+            Role.CONSUMER,
+            "user@example.com",
+            "password123!",
+            "nickname"
+        );
+
+        MemberResult memberResult = new MemberResult(
+            1L,
+            Role.CONSUMER,
+            requestDto.email(),
+            requestDto.nickname(),
+            0,
+            MemberStatus.ACTIVE,
+            null
+        );
+
+        CreateResponseDto responseDto = new CreateResponseDto(
+            memberResult.id(),
+            memberResult.email(),
+            memberResult.nickname()
+        );
+
+        when(memberServiceSelector.select(Role.CONSUMER)).thenReturn(roleBasedMemberService);
+        when(roleBasedMemberService.readMember()).thenReturn(memberResult);
+        when(memberControllerMapper.toCreateResponseDto(memberResult)).thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-User-Role", requestDto.role())
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", "/api/v1/members/" + responseDto.id()))
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(responseDto.id()))
+            .andExpect(jsonPath("$.data.email").value(responseDto.email()))
+            .andExpect(jsonPath("$.data.nickname").value(responseDto.nickname()))
+            .andExpect(jsonPath("$.error").doesNotExist());
+    }
+}

--- a/member/src/test/java/com/smore/member/presentation/web/MemberControllerTest.java
+++ b/member/src/test/java/com/smore/member/presentation/web/MemberControllerTest.java
@@ -73,7 +73,7 @@ class MemberControllerTest {
         );
 
         when(memberServiceSelector.select(Role.CONSUMER)).thenReturn(roleBasedMemberService);
-        when(roleBasedMemberService.readMember()).thenReturn(memberResult);
+        when(roleBasedMemberService.createMember(memberControllerMapper.toCreateCommand(requestDto))).thenReturn(memberResult);
         when(memberControllerMapper.toCreateResponseDto(memberResult)).thenReturn(responseDto);
 
         // when & then


### PR DESCRIPTION
## (973de60) feat: Member create 를 위한 Repository, Mapper, JpaEntity 수정 및 추가
- 비회원 Role 추가
- save 추가
- Mapper 추가
- findByEmail 의 경우 추후 Error 클래스를 만들어서 반환하도록 하겠습니다 우선적으로 없으면 null 을 반환하게 두었습니다
## (914c03e) feat: MemberService Role 별 별도 구현체 주입을 가능하게 설계
- Controller 에서 header 별 Service 를 주입받아서 사용가능 하도록 설계하였습니다
- RoleBasedMemberService 에서 모든 모듈에서 사용되지는 않는 메서드들을 예외처리 하였습니다 (ex: 비회원은 read 불가, create 는 비회원만 가능)
- AbstractMemberService 에서 공통 주입설정
## (a3868ca) feat: Member Create 를 위한 Controller 생성
- req, res dto 들은 단순 값전달 목적으로 record 사용하였습니다
  - 충돌 위험이있는 필드도 없다고 생각 됨
## (a3868ca) refactor: MemberController 내부 메서드 수정
- Controller 내부에서 create 가 아닌 read 를 호출하던 부분 수정