### PR TITLE
Order 주문 생성

### DIFF
--- a/order/build.gradle
+++ b/order/build.gradle
@@ -34,10 +34,21 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // jackson
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
 }
 
 dependencyManagement {

--- a/order/src/main/java/com/smore/order/OrderApplication.java
+++ b/order/src/main/java/com/smore/order/OrderApplication.java
@@ -2,7 +2,9 @@ package com.smore.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OrderApplication {
 

--- a/order/src/main/java/com/smore/order/application/dto/CreateOrderCommand.java
+++ b/order/src/main/java/com/smore/order/application/dto/CreateOrderCommand.java
@@ -1,0 +1,48 @@
+package com.smore.order.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateOrderCommand {
+
+    private Long userId;
+    private UUID productId;
+    private Integer productPrice;
+    private Integer quantity;
+    private UUID idempotencyKey;
+    private LocalDateTime expiresAt;
+    private String street;
+    private String city;
+    private String zipcode;
+
+    public static CreateOrderCommand create(
+        Long userId, UUID productId,
+        Integer productPrice, Integer quantity,
+        UUID idempotencyKey, LocalDateTime expiresAt,
+        String street, String city, String zipcode
+    ) {
+
+        return CreateOrderCommand.builder()
+            .userId(userId)
+            .productId(productId)
+            .productPrice(productPrice)
+            .quantity(quantity)
+            .idempotencyKey(idempotencyKey)
+            .expiresAt(expiresAt)
+            .street(street)
+            .city(city)
+            .zipcode(zipcode)
+            .build();
+
+    }
+}
+
+
+

--- a/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
@@ -1,0 +1,12 @@
+package com.smore.order.application.repository;
+
+import com.smore.order.domain.model.Order;
+import java.util.UUID;
+
+public interface OrderRepository {
+
+    Order findByIdempotencyKey(UUID idempotencyKey);
+
+    Order save(Order order);
+
+}

--- a/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
@@ -1,0 +1,11 @@
+package com.smore.order.application.repository;
+
+import com.smore.order.domain.model.Outbox;
+
+public interface OutboxRepository {
+
+    Outbox save(Outbox outbox);
+
+    Outbox findById(Long outboxId);
+
+}

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -1,0 +1,83 @@
+package com.smore.order.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.order.application.dto.CreateOrderCommand;
+import com.smore.order.application.repository.OrderRepository;
+import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.domain.event.CreatedOrderEvent;
+import com.smore.order.domain.model.Order;
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.AggregateType;
+import com.smore.order.domain.status.EventType;
+import jakarta.transaction.Transactional;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j(topic = "OrderService")
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Transactional
+    public void createOrder(CreateOrderCommand command) {
+
+        Order findOrder = orderRepository.findByIdempotencyKey(command.getIdempotencyKey());
+        if (findOrder == null) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        Order createOrder = Order.create(
+            command.getUserId(),
+            command.getProductId(),
+            command.getProductPrice(),
+            command.getQuantity(),
+            command.getIdempotencyKey(),
+            now,
+            command.getStreet(),
+            command.getCity(),
+            command.getZipcode()
+        );
+        Order saveOrder = orderRepository.save(createOrder);
+
+        CreatedOrderEvent event = CreatedOrderEvent.of(
+            saveOrder.getId(),
+            saveOrder.getUserId(),
+            saveOrder.getTotalAmount(),
+            UUID.randomUUID(),
+            now,
+            command.getExpiresAt()
+        );
+
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            saveOrder.getId(),
+            EventType.ORDER_CREATED,
+            UUID.randomUUID(),
+            makePayload(event)
+        );
+
+        outboxRepository.save(outbox);
+    }
+
+    private String makePayload(CreatedOrderEvent event)  {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            log.error("이벤트 Payload JSON 변환 실패");
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/order/src/main/java/com/smore/order/domain/event/CreatedOrderEvent.java
+++ b/order/src/main/java/com/smore/order/domain/event/CreatedOrderEvent.java
@@ -1,0 +1,35 @@
+package com.smore.order.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatedOrderEvent {
+
+    private final UUID orderId;
+    private final Long userId;
+    private final Integer totalAmount;
+    private final UUID idempotencyKey;
+    private final LocalDateTime publishedAt;
+    private final LocalDateTime expiresAt;
+
+    public static CreatedOrderEvent of(
+        UUID orderId, Long userId, Integer totalAmount, UUID idempotencyKey,
+        LocalDateTime now, LocalDateTime expiresAt) {
+
+        return CreatedOrderEvent.builder()
+            .orderId(orderId)
+            .userId(userId)
+            .totalAmount(totalAmount)
+            .idempotencyKey(idempotencyKey)
+            .publishedAt(now)
+            .expiresAt(expiresAt)
+            .build();
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -1,0 +1,69 @@
+package com.smore.order.domain.model;
+
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.domain.vo.Address;
+import com.smore.order.domain.vo.Product;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+
+    private UUID id;
+    private Long userId;
+    private Product product;
+    private Integer quantity;
+    private Integer totalAmount;
+    private Integer refundAmount;
+    private Integer feeAmount;
+    private UUID idempotencyKey;
+    private OrderStatus orderStatus;
+    private CancelState cancelState;
+    private LocalDateTime orderedAt;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private Address address;
+
+    public static Order create(
+        Long userId, UUID productId,
+        Integer productPrice, Integer quantity,
+        UUID idempotencyKey, LocalDateTime now,
+        String street, String city, String zipcode
+    ) {
+
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        if (userId == null) throw new IllegalArgumentException("유저 식별자는 필수값입니다.");
+        if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
+        if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
+        if (now == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
+
+        Integer totalAmount = calculateTotalPrice(productPrice, quantity);
+
+        return Order.builder()
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(OrderStatus.CRATED)
+            .cancelState(CancelState.NONE)
+            .orderedAt(now)
+            .address(address)
+            .build();
+    }
+
+    private static Integer calculateTotalPrice(Integer price, Integer quantity) {
+        return price * quantity;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -63,6 +63,47 @@ public class Order {
             .build();
     }
 
+    public static Order of(
+        UUID id,
+        Long userId,
+        UUID productId,
+        Integer productPrice,
+        Integer quantity,
+        Integer totalAmount,
+        Integer refundAmount,
+        Integer feeAmount,
+        UUID idempotencyKey,
+        OrderStatus orderStatus,
+        CancelState cancelState,
+        LocalDateTime orderedAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt,
+        String street,
+        String city,
+        String zipcode
+    ) {
+
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        return Order.builder()
+            .id(id)
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .refundAmount(refundAmount)
+            .feeAmount(feeAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(orderStatus)
+            .cancelState(cancelState)
+            .orderedAt(orderedAt)
+            .confirmedAt(confirmedAt)
+            .cancelledAt(cancelledAt)
+            .address(address)
+            .build();
+    }
+
     private static Integer calculateTotalPrice(Integer price, Integer quantity) {
         return price * quantity;
     }

--- a/order/src/main/java/com/smore/order/domain/model/Outbox.java
+++ b/order/src/main/java/com/smore/order/domain/model/Outbox.java
@@ -1,0 +1,75 @@
+package com.smore.order.domain.model;
+
+import com.smore.order.domain.status.AggregateType;
+import com.smore.order.domain.status.EventStatus;
+import com.smore.order.domain.status.EventType;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Outbox {
+
+    private Long id;
+
+    private AggregateType aggregateType;
+
+    private UUID aggregateId;
+
+    private EventType eventType;
+
+    private UUID idempotencyKey;
+
+    private String payload;
+
+    private EventStatus eventStatus;
+
+    public static Outbox create(
+        AggregateType aggregateType,
+        UUID aggregateId,
+        EventType eventType,
+        UUID idempotencyKey,
+        String payload
+    ) {
+        if (aggregateType == null) throw new IllegalArgumentException("aggregateType은 필수값입니다.");
+        if (aggregateId == null) throw new IllegalArgumentException("aggregateId는 필수값입니다.");
+        if (eventType == null) throw new IllegalArgumentException("eventType은 필수값입니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("idempotencyKey는 필수값입니다.");
+        if (payload == null) throw new IllegalArgumentException("payload는 필수값입니다.");
+
+        return Outbox.builder()
+            .aggregateType(aggregateType)
+            .aggregateId(aggregateId)
+            .eventType(eventType)
+            .idempotencyKey(idempotencyKey)
+            .payload(payload)
+            .eventStatus(EventStatus.PENDING)
+            .build();
+    }
+
+    public static Outbox of(
+        Long id,
+        AggregateType aggregateType,
+        UUID aggregateId,
+        EventType eventType,
+        UUID idempotencyKey,
+        String payload,
+        EventStatus eventStatus
+    ) {
+
+        return Outbox.builder()
+            .id(id)
+            .aggregateType(aggregateType)
+            .aggregateId(aggregateId)
+            .eventType(eventType)
+            .idempotencyKey(idempotencyKey)
+            .payload(payload)
+            .eventStatus(eventStatus)
+            .build();
+    }
+
+}

--- a/order/src/main/java/com/smore/order/domain/status/AggregateType.java
+++ b/order/src/main/java/com/smore/order/domain/status/AggregateType.java
@@ -1,0 +1,15 @@
+package com.smore.order.domain.status;
+
+public enum AggregateType {
+    BID("판매 경쟁 이벤트"),
+    AUCTION("경매 이벤트"),
+    ORDER("주문 이벤트"),
+    PAYMENT("결제 이벤트")
+    ;
+
+    private final String description;
+
+    AggregateType(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/CancelState.java
+++ b/order/src/main/java/com/smore/order/domain/status/CancelState.java
@@ -1,0 +1,14 @@
+package com.smore.order.domain.status;
+
+public enum CancelState {
+    NONE("주문"),
+    CANCEL_REQUESTED("주문 취소 요청"),
+    CANCELLED("주문 취소 완료")
+    ;
+
+    private final String description;
+
+    CancelState(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/EventStatus.java
+++ b/order/src/main/java/com/smore/order/domain/status/EventStatus.java
@@ -1,0 +1,16 @@
+package com.smore.order.domain.status;
+
+public enum EventStatus {
+
+    PENDING("전송 대기중"),
+    PROCESSING("처리 중"),
+    SENT("전송 완료"),
+    FAILED("영구 실패")
+    ;
+
+    private final String description;
+
+    EventStatus(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/EventType.java
+++ b/order/src/main/java/com/smore/order/domain/status/EventType.java
@@ -1,0 +1,17 @@
+package com.smore.order.domain.status;
+
+public enum EventType {
+    ORDER_CREATED("주문 생성 완료"),
+    ORDER_COMPLETED("주문 완료"),
+    ORDER_FAILED("주문 실패"),
+    PAYMENT_CANCEL("결제 취소 요청"),
+    ORDER_CANCELLED("주문 취소 완료")
+    ;
+
+    private final String description;
+
+    EventType(String description) {
+        this.description = description;
+    }
+
+}

--- a/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
+++ b/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
@@ -1,0 +1,15 @@
+package com.smore.order.domain.status;
+
+public enum OrderStatus {
+    CRATED("주문 생성"),
+    COMPLETED("주문 완료"),
+    FAILED("주문 실패"),
+    CANCELLED("주문 취소")
+    ;
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/vo/Address.java
+++ b/order/src/main/java/com/smore/order/domain/vo/Address.java
@@ -1,0 +1,19 @@
+package com.smore.order.domain.vo;
+
+public record Address(
+    String street,
+    String city,
+    String zipcode
+) {
+    public Address {
+        if (street == null || street.isBlank()) {
+            throw new IllegalArgumentException("도로 명 주소 필수 입력");
+        }
+        if (city == null || city.isBlank()) {
+            throw new IllegalArgumentException("지번 주소 필수 입력");
+        }
+        if (zipcode == null || zipcode.isBlank()) {
+            throw new IllegalArgumentException("우편 번호 필수 입력");
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/vo/Product.java
+++ b/order/src/main/java/com/smore/order/domain/vo/Product.java
@@ -1,0 +1,14 @@
+package com.smore.order.domain.vo;
+
+import java.util.UUID;
+
+public record Product(
+    UUID productId,
+    Integer productPrice
+) {
+    public Product {
+        if (productId == null) throw new IllegalArgumentException("productId는 필수값입니다.");
+        if (productPrice == null) throw new IllegalArgumentException("상품 가격은 필수값입니다.");
+        if (productPrice < 0) throw new IllegalArgumentException("상품 가격은 음수일 수 없습니다.");
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/config/AppConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.smore.order.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/config/AppConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/AppConfig.java
@@ -1,6 +1,8 @@
 package com.smore.order.infrastructure.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,7 +11,9 @@ public class AppConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/config/JpaConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/JpaConfig.java
@@ -1,0 +1,16 @@
+package com.smore.order.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/config/TimeConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.smore.order.infrastructure.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/BaseEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/BaseEntity.java
@@ -1,0 +1,39 @@
+package com.smore.order.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@FilterDef(
+    name = "softDeleteFilter",
+    defaultCondition = "deleted_at IS NULL",
+    autoEnabled = true,
+    applyToLoadByKey = true
+)
+@Filter(name = "softDeleteFilter")
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private Long deletedBy;
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Address.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Address.java
@@ -1,0 +1,32 @@
+package com.smore.order.infrastructure.persistence.entity.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+
+    @Column(name = "street", nullable = false)
+    private String street;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    @Column(name = "zipcode", nullable = false)
+    private String zipcode;
+
+    protected Address(String street, String city, String zipcode) {
+        if (street == null || street.isBlank()) throw new IllegalArgumentException("도로 명 주소 필수 입력");
+        if (city == null || city.isBlank()) throw new IllegalArgumentException("지번 주소 필수 입력");
+        if (zipcode == null || zipcode.isBlank()) throw new IllegalArgumentException("우편 번호 필수 입력");
+        this.street = street;
+        this.city = city;
+        this.zipcode = zipcode;
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Address.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Address.java
@@ -3,11 +3,13 @@ package com.smore.order.infrastructure.persistence.entity.order;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@Builder(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address {
 

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
@@ -1,0 +1,112 @@
+package com.smore.order.infrastructure.persistence.entity.order;
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.infrastructure.persistence.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    name = "p_order",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_order_idempotency_key",
+        columnNames = {"idempotency_key"}
+    )
+)
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderEntity extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Embedded
+    private Product product;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "total_amount", nullable = false)
+    private Integer totalAmount;
+
+    @Column(name = "refund_amount")
+    private Integer refundAmount;
+
+    @Column(name = "fee_amount")
+    private Integer feeAmount;
+
+    @Column(name = "idempotency_key", nullable = false)
+    private UUID idempotencyKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status", nullable = false)
+    private OrderStatus orderStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cancel_status", nullable = false)
+    private CancelState cancelState;
+
+    @Column(name = "ordered_at", nullable = false)
+    private LocalDateTime orderedAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Embedded
+    private Address address;
+
+    public static OrderEntity create(
+        Long userId,
+        UUID productId, Integer productPrice, Integer quantity, Integer totalAmount,
+        UUID idempotencyKey, OrderStatus orderStatus, CancelState cancelState,
+        LocalDateTime orderedAt,
+        String street, String city, String zipcode
+    ) {
+        Product product = new Product(productId, productPrice);
+        Address address = new Address(street, city, zipcode);
+
+        if (userId == null) throw new IllegalArgumentException("유저 식별자는 필수값입니다.");
+        if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
+        if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
+        if (orderStatus == OrderStatus.CRATED) throw new IllegalArgumentException("주문 생성 시 OrderStatus의 상태는 CREATED 상태여야 합니다.");
+        if (cancelState == CancelState.NONE) throw new IllegalArgumentException("주문 생성 시 CancelStatus의 상태는 NONE 상태여야 합니다.");
+        if (orderedAt == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
+
+        return OrderEntity.builder()
+            .userId(userId)
+            .product(product)
+            .quantity(quantity)
+            .totalAmount(totalAmount)
+            .idempotencyKey(idempotencyKey)
+            .orderStatus(orderStatus)
+            .cancelState(cancelState)
+            .orderedAt(orderedAt)
+            .address(address)
+            .build();
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
@@ -93,8 +93,8 @@ public class OrderEntity extends BaseEntity {
         if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
         if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
         if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
-        if (orderStatus == OrderStatus.CRATED) throw new IllegalArgumentException("주문 생성 시 OrderStatus의 상태는 CREATED 상태여야 합니다.");
-        if (cancelState == CancelState.NONE) throw new IllegalArgumentException("주문 생성 시 CancelStatus의 상태는 NONE 상태여야 합니다.");
+        if (orderStatus != OrderStatus.CRATED) throw new IllegalArgumentException("주문 생성 시 OrderStatus의 상태는 CREATED 상태여야 합니다.");
+        if (cancelState != CancelState.NONE) throw new IllegalArgumentException("주문 생성 시 CancelStatus의 상태는 NONE 상태여야 합니다.");
         if (orderedAt == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
 
         return OrderEntity.builder()

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Product.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Product.java
@@ -1,0 +1,30 @@
+package com.smore.order.infrastructure.persistence.entity.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Column(name = "product_price", nullable = false)
+    private Integer productPrice;
+
+    protected Product(UUID productId, Integer productPrice) {
+        if (productId == null) throw new IllegalArgumentException("상품의 아이디는 필수입니다.");
+        if (productPrice == null) throw new IllegalArgumentException("상품 가격은 필수값입니다.");
+        if (productPrice < 0) throw new IllegalArgumentException("상품 가격은 음수일 수 없습니다.");
+        this.productId = productId;
+        this.productPrice = productPrice;
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Product.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/Product.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@Builder(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product {
     @Column(name = "product_id", nullable = false)

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/outbox/OutboxEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/outbox/OutboxEntity.java
@@ -1,0 +1,78 @@
+package com.smore.order.infrastructure.persistence.entity.outbox;
+
+import com.smore.order.domain.status.AggregateType;
+import com.smore.order.domain.status.EventStatus;
+import com.smore.order.domain.status.EventType;
+import com.smore.order.infrastructure.persistence.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Table(
+    name = "p_order_outbox",
+    indexes = {
+        @Index(name = "idx_outbox_status_created_at", columnList = "event_status, created_at")
+    }
+)
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEntity extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private AggregateType aggregateType;
+
+    private UUID aggregateId;
+
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+
+    private UUID idempotencyKey;
+
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    private EventStatus eventStatus;
+
+    public static OutboxEntity create(
+        AggregateType aggregateType,
+        UUID aggregateId,
+        EventType eventType,
+        UUID idempotencyKey,
+        String payload,
+        EventStatus eventStatus
+    ) {
+
+        if (aggregateType == null) throw new IllegalArgumentException("aggregateType은 필수값입니다.");
+        if (aggregateId == null) throw new IllegalArgumentException("aggregateId는 필수값입니다.");
+        if (eventType == null) throw new IllegalArgumentException("idempotencyKey는 필수값입니다.");
+        if (payload == null) throw new IllegalArgumentException("payload는 필수값입니다.");
+
+        return OutboxEntity.builder()
+            .aggregateType(aggregateType)
+            .aggregateId(aggregateId)
+            .eventType(eventType)
+            .idempotencyKey(idempotencyKey)
+            .payload(payload)
+            .eventStatus(eventStatus)
+            .build();
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/exception/CreateOrderFailException.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/exception/CreateOrderFailException.java
@@ -1,0 +1,8 @@
+package com.smore.order.infrastructure.persistence.exception;
+
+public class CreateOrderFailException extends RuntimeException {
+
+    public CreateOrderFailException(String message) {
+        super(message);
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/exception/CreateOutboxFailException.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/exception/CreateOutboxFailException.java
@@ -1,0 +1,8 @@
+package com.smore.order.infrastructure.persistence.exception;
+
+public class CreateOutboxFailException extends RuntimeException {
+
+    public CreateOutboxFailException(String message) {
+        super(message);
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/exception/NotFoundOutboxException.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/exception/NotFoundOutboxException.java
@@ -1,0 +1,8 @@
+package com.smore.order.infrastructure.persistence.exception;
+
+public class NotFoundOutboxException extends RuntimeException {
+
+    public NotFoundOutboxException(String message) {
+        super(message);
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OrderMapper.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OrderMapper.java
@@ -1,0 +1,59 @@
+package com.smore.order.infrastructure.persistence.mapper;
+
+
+import com.smore.order.domain.model.Order;
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+
+public final class OrderMapper {
+
+    private OrderMapper() {
+
+    }
+
+    public static OrderEntity toEntityForCreate(Order order) {
+        if (order == null) {
+            return null;
+        }
+
+        return OrderEntity.create(
+            order.getUserId(),
+            order.getProduct().productId(),
+            order.getProduct().productPrice(),
+            order.getQuantity(),
+            order.getTotalAmount(),
+            order.getIdempotencyKey(),
+            order.getOrderStatus(),
+            order.getCancelState(),
+            order.getOrderedAt(),
+            order.getAddress().street(),
+            order.getAddress().city(),
+            order.getAddress().zipcode()
+        );
+    }
+
+    public static Order toDomain(OrderEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return Order.of(
+            entity.getId(),
+            entity.getUserId(),
+            entity.getProduct().getProductId(),
+            entity.getProduct().getProductPrice(),
+            entity.getQuantity(),
+            entity.getTotalAmount(),
+            entity.getRefundAmount(),
+            entity.getFeeAmount(),
+            entity.getIdempotencyKey(),
+            entity.getOrderStatus(),
+            entity.getCancelState(),
+            entity.getOrderedAt(),
+            entity.getConfirmedAt(),
+            entity.getCancelledAt(),
+            entity.getAddress().getStreet(),
+            entity.getAddress().getCity(),
+            entity.getAddress().getZipcode()
+        );
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OutboxMapper.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OutboxMapper.java
@@ -1,0 +1,42 @@
+package com.smore.order.infrastructure.persistence.mapper;
+
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
+
+public final class OutboxMapper {
+
+    private OutboxMapper() {
+
+    }
+
+    public static OutboxEntity toEntityForCreate(Outbox outbox) {
+        if (outbox == null) {
+            return null;
+        }
+
+        return OutboxEntity.create(
+            outbox.getAggregateType(),
+            outbox.getAggregateId(),
+            outbox.getEventType(),
+            outbox.getIdempotencyKey(),
+            outbox.getPayload(),
+            outbox.getEventStatus()
+        );
+    }
+
+    public static Outbox toDomain(OutboxEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return Outbox.of(
+            entity.getId(),
+            entity.getAggregateType(),
+            entity.getAggregateId(),
+            entity.getEventType(),
+            entity.getIdempotencyKey(),
+            entity.getPayload(),
+            entity.getEventStatus()
+        );
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepository.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepository.java
@@ -1,0 +1,10 @@
+package com.smore.order.infrastructure.persistence.repository.order;
+
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID>,
+    OrderJpaRepositoryCustom {
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.smore.order.infrastructure.persistence.repository.order;
+
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+import java.util.UUID;
+
+public interface OrderJpaRepositoryCustom {
+
+    OrderEntity findByIdempotencyKey(UUID idempotencyKey);
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.smore.order.infrastructure.persistence.repository.order;
+
+import static com.smore.order.infrastructure.persistence.entity.order.QOrderEntity.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+import jakarta.persistence.EntityManager;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public OrderEntity findByIdempotencyKey(UUID idempotencyKey) {
+        return queryFactory
+            .select(orderEntity)
+            .from(orderEntity)
+            .where(
+                orderEntity.idempotencyKey.eq(idempotencyKey)
+            )
+            .fetchOne();
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.smore.order.infrastructure.persistence.repository.order;
+
+import com.smore.order.application.repository.OrderRepository;
+import com.smore.order.domain.model.Order;
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+import com.smore.order.infrastructure.persistence.exception.CreateOrderFailException;
+import com.smore.order.infrastructure.persistence.mapper.OrderMapper;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j(topic = "OrderRepositoryImpl")
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+
+    private final OrderJpaRepository orderJpaRepository;
+
+    @Override
+    public Order findByIdempotencyKey(UUID idempotencyKey) {
+
+        if (idempotencyKey == null){
+            log.error("idempotencyKey is Null : method = {}", "findByIdempotencyKey()");
+            throw new IllegalArgumentException("idempotencyKey가 null입니다.");
+        }
+
+        OrderEntity entity = orderJpaRepository.findByIdempotencyKey(idempotencyKey);
+
+        if (entity == null) return null;
+        return OrderMapper.toDomain(entity);
+    }
+
+    @Override
+    public Order save(Order order) {
+        if (order == null){
+            log.error("order is Null : methodName = {}", "save()");
+            throw new IllegalArgumentException("order가 null 입니다.");
+        }
+
+        OrderEntity entity = orderJpaRepository.save(
+            OrderMapper.toEntityForCreate(order)
+        );
+
+        if (entity == null) {
+            log.error("entity is Null : methodName = {}", "save()");
+            throw new CreateOrderFailException("주문이 생성되지 않았습니다.");
+        }
+        return OrderMapper.toDomain(entity);
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepository.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepository.java
@@ -1,0 +1,9 @@
+package com.smore.order.infrastructure.persistence.repository.outbox;
+
+import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, Long>,
+    OutboxJpaRepositoryCustom {
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.smore.order.infrastructure.persistence.repository.outbox;
+
+public interface OutboxJpaRepositoryCustom {
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
@@ -1,0 +1,5 @@
+package com.smore.order.infrastructure.persistence.repository.outbox;
+
+public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom {
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.smore.order.infrastructure.persistence.repository.outbox;
+
+import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
+import com.smore.order.infrastructure.persistence.exception.CreateOutboxFailException;
+import com.smore.order.infrastructure.persistence.exception.NotFoundOutboxException;
+import com.smore.order.infrastructure.persistence.mapper.OutboxMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j(topic = "OutboxRepositoryImpl")
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public Outbox save(Outbox outbox) {
+
+        if (outbox == null) {
+            log.error("outbox is Null : method = {}", "save()");
+            throw new IllegalArgumentException("outbox null입니다.");
+        }
+
+         OutboxEntity entity = outboxJpaRepository.save(
+            OutboxMapper.toEntityForCreate(outbox));
+
+        if (entity == null) {
+            log.error("entity is Null : method = {}", "save()");
+            throw new CreateOutboxFailException("이벤트를 outbox에 저장하지 못했습니다.");
+        }
+        return OutboxMapper.toDomain(entity);
+    }
+
+    @Override
+    public Outbox findById(Long outboxId) {
+
+        if (outboxId == null) {
+            log.error("outboxId is Null : method = {}", "findById()");
+            throw new IllegalArgumentException("outboxId가 null입니다.");
+        }
+
+        OutboxEntity entity = outboxJpaRepository.findById(outboxId).orElseThrow(
+            () -> new NotFoundOutboxException("outbox를 찾을 수 없습니다.")
+        );
+
+        return OutboxMapper.toDomain(entity);
+    }
+
+}

--- a/order/src/test/java/com/smore/order/application/service/OrderServiceTest.java
+++ b/order/src/test/java/com/smore/order/application/service/OrderServiceTest.java
@@ -1,0 +1,160 @@
+package com.smore.order.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.smore.order.application.dto.CreateOrderCommand;
+import com.smore.order.application.repository.OrderRepository;
+import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.domain.model.Order;
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.AggregateType;
+import com.smore.order.domain.status.EventType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    OrderRepository orderRepository;
+
+    @Mock
+    OutboxRepository outboxRepository;
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Mock
+    Clock clock;
+
+    @InjectMocks
+    OrderService orderService;
+
+    @DisplayName("만약 이미 등록된 주문이라면 createOrder는 즉시 리턴되고 주문을 생성하지 않는다.")
+    @Test
+    void createOrderIdempotencyKeyTest() {
+        // given
+        CreateOrderCommand command = CreateOrderCommand.create(
+            1L,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            10000,
+            2,
+            UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            LocalDateTime.of(2025, 11, 30, 12, 0, 0),
+            "서울시 강남구 테헤란로 1",
+            "서울시",
+            "06234"
+        );
+
+        Mockito.when(orderRepository.findByIdempotencyKey(command.getIdempotencyKey()))
+            .thenReturn(null);
+
+        // when
+        orderService.createOrder(command);
+
+        // then
+        Mockito.verify(
+            orderRepository, Mockito.times(1)
+        ).findByIdempotencyKey(command.getIdempotencyKey());
+
+        Mockito.verify(
+            orderRepository, Mockito.times(0)
+        ).save(Mockito.any());
+
+        Mockito.verify(
+            outboxRepository, Mockito.times(0)
+        ).save(Mockito.any());
+    }
+
+    @DisplayName("만약 이미 등록된 주문이라면 createOrder는 즉시 리턴되고 주문을 생성하지 않는다.")
+    @Test
+    void createOrderIdempotencyKeyTest2() {
+        // given
+        Instant fixedInstant = Instant.parse("2025-10-11T00:00:00Z");
+
+        Mockito.when(clock.instant()).thenReturn(fixedInstant);
+        Mockito.when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
+
+        CreateOrderCommand command = CreateOrderCommand.create(
+            1L,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            10000,
+            2,
+            UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            LocalDateTime.of(2025, 11, 30, 12, 0, 0),
+            "서울시 강남구 테헤란로 1",
+            "서울시",
+            "06234"
+        );
+
+        Order order = Order.create(
+            1L,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            10_000,
+            2,
+            UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            LocalDateTime.of(2025, 11, 30, 12, 0, 0),
+            "서울시 강남구 테헤란로 1",
+            "서울시",
+            "06234"
+        );
+
+        ReflectionTestUtils.setField(order, "id",
+            UUID.fromString("3f9b8c1d-4e7e-4c1a-a8fd-2a6a7f9c3b44"));
+
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            order.getId(),
+            EventType.ORDER_CREATED,
+            UUID.randomUUID(),
+            "payload"
+        );
+
+        ReflectionTestUtils.setField(outbox, "id",
+            1L);
+
+        Mockito.when(orderRepository.findByIdempotencyKey(command.getIdempotencyKey()))
+            .thenReturn(order);
+
+        Mockito.when(orderRepository.save(Mockito.any(Order.class)))
+            .thenReturn(order);
+
+        Mockito.when(outboxRepository.save(Mockito.any(Outbox.class)))
+            .thenReturn(outbox);
+
+        // when
+        orderService.createOrder(command);
+
+        // then
+        Mockito.verify(
+            orderRepository, Mockito.times(1)
+        ).findByIdempotencyKey(command.getIdempotencyKey());
+
+        Mockito.verify(
+            orderRepository, Mockito.times(1)
+        ).save(Mockito.any());
+
+        Mockito.verify(
+            outboxRepository, Mockito.times(1)
+        ).save(Mockito.any());
+    }
+
+
+}

--- a/order/src/test/java/com/smore/order/application/service/OrderServiceTest.java
+++ b/order/src/test/java/com/smore/order/application/service/OrderServiceTest.java
@@ -83,9 +83,9 @@ class OrderServiceTest {
         ).save(Mockito.any());
     }
 
-    @DisplayName("만약 이미 등록된 주문이라면 createOrder는 즉시 리턴되고 주문을 생성하지 않는다.")
+    @DisplayName("createOrder 성공 케이스 테스트 코드")
     @Test
-    void createOrderIdempotencyKeyTest2() {
+    void createOrder() {
         // given
         Instant fixedInstant = Instant.parse("2025-10-11T00:00:00Z");
 

--- a/order/src/test/java/com/smore/order/domain/model/OrderTest.java
+++ b/order/src/test/java/com/smore/order/domain/model/OrderTest.java
@@ -1,0 +1,452 @@
+package com.smore.order.domain.model;
+
+import com.smore.order.domain.status.CancelState;
+import com.smore.order.domain.status.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OrderTest {
+
+    @DisplayName("주문을 생성할 때 userId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenUserIdIsNull() {
+        // given
+        Long userId = null;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("유저 식별자는 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductIdIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = null;
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("productId는 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productId가 null이라면 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductPriceIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = null;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("상품 가격은 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 productPrice가 음수일 수 없습니다. IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenProductPriceIsNegativeNumber() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = -1;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("상품 가격은 음수일 수 없습니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 street 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenStreetIsNull(String street) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("도로 명 주소 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 city 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenCityIsNull(String city) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("지번 주소 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주소의 city 값이 null이거나 blank인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void createOrderFailWhenZipcodeIsNull(String zipcode) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("우편 번호 필수 입력");
+    }
+
+    @DisplayName("주문을 생성할 때 주문 수량이 null인 경우  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @NullSource
+    void createOrderFailWhenQuantityIsNull(Integer quantity) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("주문 수량은 필수값입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 주문 수량이 0 이하인 경우 IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void createOrderFailInvalidQuantity(Integer quantity) {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("주문 수량은 1개 이상이어야 합니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 멱등키가 null이라면  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenIdempotencyKeyIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = null;
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("멱등키는 필수입니다.");
+    }
+
+    @DisplayName("주문을 생성할 때 멱등키가 null이라면  IllegalArgumentException 예외가 발생하며 주문 도메인 생성에 실패한다.")
+    @Test
+    void createOrderFailWhenNowIsNull() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = null;
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> Order.create(
+                userId,
+                productId,
+                productPrice,
+                quantity,
+                idempotencyKey,
+                now,
+                street,
+                city,
+                zipcode
+            ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("현재 날짜는 필수입니다.");
+    }
+
+    @DisplayName("주문이 정상적으로 생성되었는지 테스트")
+    @Test
+    void createOrder() {
+        // given
+        Long userId = 1L;
+
+        UUID productId = UUID.fromString("c5d7e9a9-2e86-4947-9a12-2dd6a0b980da");
+        Integer productPrice = 15000;
+
+        Integer quantity = 10;
+
+        UUID idempotencyKey = UUID.fromString("b3fb0b90-4a22-49e9-a3b3-8dc98d85e2b1");
+        LocalDateTime now = LocalDateTime.of(2025, 11, 29, 12, 0, 0);
+
+        String street = "테헤란로 152";
+        String city = "서울특별시 강남구";
+        String zipcode = "06236";
+
+        // when // then
+        Order order = Order.create(
+            userId,
+            productId,
+            productPrice,
+            quantity,
+            idempotencyKey,
+            now,
+            street,
+            city,
+            zipcode
+        );
+
+        // then
+        Assertions.assertThat(order).isNotNull();
+        Assertions.assertThat(order.getUserId()).isEqualTo(userId);
+
+        Assertions.assertThat(order.getProduct()).isNotNull();
+        Assertions.assertThat(order.getProduct().productId()).isEqualTo(productId);
+        Assertions.assertThat(order.getProduct().productPrice()).isEqualTo(productPrice);
+
+        Assertions.assertThat(order.getQuantity()).isEqualTo(quantity);
+        Assertions.assertThat(order.getTotalAmount()).isEqualTo(productPrice * quantity);
+
+        Assertions.assertThat(order.getIdempotencyKey()).isEqualTo(idempotencyKey);
+        Assertions.assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CRATED);
+        Assertions.assertThat(order.getCancelState()).isEqualTo(CancelState.NONE);
+
+        Assertions.assertThat(order.getOrderedAt()).isEqualTo(now);
+
+        Assertions.assertThat(order.getAddress()).isNotNull();
+        Assertions.assertThat(order.getAddress().street()).isEqualTo(street);
+        Assertions.assertThat(order.getAddress().city()).isEqualTo(city);
+        Assertions.assertThat(order.getAddress().zipcode()).isEqualTo(zipcode);
+
+        Assertions.assertThat(order.getId()).isNull();
+        Assertions.assertThat(order.getRefundAmount()).isNull();
+        Assertions.assertThat(order.getFeeAmount()).isNull();
+        Assertions.assertThat(order.getConfirmedAt()).isNull();
+        Assertions.assertThat(order.getCancelledAt()).isNull();
+
+    }
+
+}

--- a/order/src/test/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImplTest.java
+++ b/order/src/test/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImplTest.java
@@ -1,0 +1,97 @@
+package com.smore.order.infrastructure.persistence.repository.order;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import com.smore.order.application.repository.OrderRepository;
+import com.smore.order.domain.model.Order;
+import com.smore.order.infrastructure.config.JpaConfig;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(
+    {
+        JpaConfig.class,
+        OrderRepositoryImpl.class
+    }
+)
+@ActiveProfiles("test")
+class OrderRepositoryImplTest {
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @DisplayName("주문 생성을 등록하고 멱등키를 활용하여 주문을 조회할 수 있다.")
+    @Test
+    void save_and_findByIdempotencyKeyTest() {
+        // given
+        Long userId = 1L;
+        UUID productId = UUID.randomUUID();
+        int productPrice = 10_000;
+        int quantity = 2;
+        UUID idempotencyKey = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.of(2025, 11, 30, 12, 0, 0);
+        String street = "서울시 강남구 테헤란로 1";
+        String city = "서울시";
+        String zipcode = "06234";
+
+        Order order = Order.create(
+            userId,
+            productId,
+            productPrice,
+            quantity,
+            idempotencyKey,
+            now,
+            street,
+            city,
+            zipcode
+        );
+
+        // when
+        orderRepository.save(order);
+
+        em.flush();
+        em.clear();
+
+        Order findOrder = orderRepository.findByIdempotencyKey(idempotencyKey);
+        // then
+
+        Assertions.assertThat(findOrder).isNotNull();
+        Assertions.assertThat(findOrder.getId()).isNotNull(); // UUID 자동 생성됐는지 확인
+
+        Assertions.assertThat(findOrder.getUserId()).isEqualTo(userId);
+
+        Assertions.assertThat(findOrder.getProduct()).isNotNull();
+        Assertions.assertThat(findOrder.getProduct().productId()).isEqualTo(productId);
+        Assertions.assertThat(findOrder.getProduct().productPrice()).isEqualTo(productPrice);
+
+        Assertions.assertThat(findOrder.getQuantity()).isEqualTo(quantity);
+
+        Assertions.assertThat(findOrder.getIdempotencyKey()).isEqualTo(idempotencyKey);
+        Assertions.assertThat(findOrder.getOrderedAt()).isEqualTo(now);
+
+        Assertions.assertThat(findOrder.getAddress()).isNotNull();
+        Assertions.assertThat(findOrder.getAddress().street()).isEqualTo(street);
+        Assertions.assertThat(findOrder.getAddress().city()).isEqualTo(city);
+        Assertions.assertThat(findOrder.getAddress().zipcode()).isEqualTo(zipcode);
+
+        Assertions.assertThat(findOrder.getRefundAmount()).isNull();
+        Assertions.assertThat(findOrder.getFeeAmount()).isNull();
+        Assertions.assertThat(findOrder.getConfirmedAt()).isNull();
+        Assertions.assertThat(findOrder.getCancelledAt()).isNull();
+
+    }
+
+}

--- a/order/src/test/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImplTest.java
+++ b/order/src/test/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImplTest.java
@@ -1,0 +1,76 @@
+package com.smore.order.infrastructure.persistence.repository.outbox;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.AggregateType;
+import com.smore.order.domain.status.EventType;
+import com.smore.order.infrastructure.config.JpaConfig;
+import jakarta.persistence.EntityManager;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(
+    {
+        JpaConfig.class,
+        OutboxRepositoryImpl.class
+    }
+)
+@ActiveProfiles("test")
+class OutboxRepositoryImplTest {
+
+    @Autowired
+    OutboxRepository outboxRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @DisplayName("outbox에 적합한 데이터가 삽입되면 outbox 테이블에 정상 등록됩니다.")
+    @Test
+    void outboxSave() {
+        // given
+        AggregateType aggregateType = AggregateType.ORDER;
+        UUID aggregateId = UUID.randomUUID();
+        EventType eventType = EventType.ORDER_CREATED;
+        UUID idempotencyKey = UUID.randomUUID();
+        String payload = "테스트 데이터";
+
+        Outbox outbox = Outbox.create(
+            aggregateType,
+            aggregateId,
+            eventType,
+            idempotencyKey,
+            payload
+        );
+
+        // when
+        outbox = outboxRepository.save(outbox);
+
+        // then
+        Assertions.assertThat(outbox.getId()).isNotNull();
+        Assertions.assertThat(outbox.getAggregateId()).isEqualTo(aggregateId);
+        Assertions.assertThat(outbox.getAggregateType()).isEqualTo(aggregateType);
+        Assertions.assertThat(outbox.getEventType()).isEqualTo(eventType);
+        Assertions.assertThat(outbox.getIdempotencyKey()).isEqualTo(idempotencyKey);
+        Assertions.assertThat(outbox.getPayload()).isEqualTo(payload);
+    }
+
+    @DisplayName("save() 메서드의 인자가 null인 경우 IllegalArgumentException 예외하여 저장되지 않는다.")
+    @Test
+    void outboxSaveWhenOutboxIsNull() {
+
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.save(null)
+            ).isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("outbox null입니다.");
+    }
+
+}

--- a/order/src/test/resources/application-test.yml
+++ b/order/src/test/resources/application-test.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    import: ""           # configserver import 완전 해제
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+    jpa:
+      hibernate:
+        ddl-auto: create-drop
+
+      properties:
+        hibernate:
+          show_sql: true
+          format_sql: true
+          dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
### 주문 생성 시나리오 
<img width="1684" height="1090" alt="image" src="https://github.com/user-attachments/assets/4c644451-f835-49aa-adc2-d6f48dccfd6b" />

1. `Bid`(주문 경쟁) 혹은 `Auction`(경매) 서비스에서 주문할 상품, 상품 가격, 구매자 정보 등을 포함한 이벤트를 `Order` 서비스로 전달한다. 
2. `OrderService`의 이벤트 리스너는 이를 확인하고 주문 생성 메서드를 호출한다.
3. 주문 생성 메서드는 임시 주문을 생성하고 DB에 등록한다.
4. 주문 생성 완료 이벤트 발행을 위해 `outbox`에 이벤트를 발행할 메시지를 기록한다.
5. 트랜잭션을 커밋한다.
6. `outbox`에서 발행할 이벤트들을 읽어와 이벤트를 발행한다.

### 구현된 내용 
- 주문 생성 서비스 로직 추가 
  - 임시 주문 생성
  - 임시 주문 생성 후, `outbox`에 발행할 이벤트 기록 
  - `createOrder` 테스트 코드 추가
  - `Repository` 테스트 코드 추가 
