### PR TITLE
Feat/product create - 상품 생성 기능 구현

### DIFF
--- a/product/src/main/java/com/smore/product/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/controller/ProductController.java
@@ -1,0 +1,27 @@
+package com.smore.product.controller;
+
+import com.smore.product.domain.dto.CreateProductRequest;
+import com.smore.product.domain.dto.ProductResponse;
+import com.smore.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products")
+public class ProductController {
+    private final ProductService productService;
+
+    @PostMapping
+    public ResponseEntity<ProductResponse> create(
+            @RequestBody CreateProductRequest request
+    ) {
+        ProductResponse response = productService.createProduct(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/product/src/main/java/com/smore/product/domain/dto/CreateProductRequest.java
+++ b/product/src/main/java/com/smore/product/domain/dto/CreateProductRequest.java
@@ -1,0 +1,21 @@
+package com.smore.product.domain.dto;
+
+import com.smore.product.domain.entity.SaleType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateProductRequest {
+    private UUID sellerId;
+    private UUID categoryId;
+    private String name;
+    private String description;
+    private int price;
+    private int stock;
+    private SaleType saleType;
+    private Integer thresholdForAuction;
+}

--- a/product/src/main/java/com/smore/product/domain/dto/ProductResponse.java
+++ b/product/src/main/java/com/smore/product/domain/dto/ProductResponse.java
@@ -1,0 +1,40 @@
+package com.smore.product.domain.dto;
+
+import com.smore.product.domain.entity.Product;
+import com.smore.product.domain.entity.ProductStatus;
+import com.smore.product.domain.entity.SaleType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class ProductResponse {
+    private UUID id;
+    private UUID sellerId;
+    private UUID categoryId;
+    private String name;
+    private String description;
+    private int price;
+    private int stock;
+    private SaleType saleType;
+    private Integer thresholdForAuction;
+    private ProductStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public ProductResponse(Product p) {
+        this.id = p.getId();
+        this.sellerId = p.getSellerId();
+        this.categoryId = p.getCategoryId();
+        this.name = p.getName();
+        this.description = p.getDescription();
+        this.price = p.getPrice();
+        this.stock = p.getStock();
+        this.saleType = p.getSaleType();
+        this.thresholdForAuction = p.getThresholdForAuction();
+        this.status = p.getStatus();
+        this.createdAt = p.getCreatedAt();
+        this.updatedAt = p.getUpdatedAt();
+    }
+}

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -1,0 +1,59 @@
+package com.smore.product.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+
+public class Product {
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    private UUID sellerId;
+
+    private UUID categoryId;
+
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private int price;
+
+    private int stock;
+
+    @Enumerated(EnumType.STRING)
+    private SaleType saleType;
+
+    private Integer thresholdForAuction;
+
+    @Enumerated(EnumType.STRING)
+    private ProductStatus status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private UUID deletedBy;
+
+    @PrePersist
+    public void onCreate() {
+        this.status = ProductStatus.ON_SALE;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/product/src/main/java/com/smore/product/domain/entity/ProductStatus.java
+++ b/product/src/main/java/com/smore/product/domain/entity/ProductStatus.java
@@ -1,0 +1,7 @@
+package com.smore.product.domain.entity;
+
+public enum ProductStatus {
+    ON_SALE,
+    SOLD_OUT,
+    INACTIVE
+}

--- a/product/src/main/java/com/smore/product/domain/entity/SaleType.java
+++ b/product/src/main/java/com/smore/product/domain/entity/SaleType.java
@@ -1,0 +1,7 @@
+package com.smore.product.domain.entity;
+
+public enum SaleType {
+    NORMAL,
+    AUCTION,
+    LIMITED_TO_AUCTION
+}

--- a/product/src/main/java/com/smore/product/domain/repository/ProductRepository.java
+++ b/product/src/main/java/com/smore/product/domain/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.smore.product.domain.repository;
+
+import com.smore.product.domain.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+}

--- a/product/src/main/java/com/smore/product/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/service/ProductService.java
@@ -1,0 +1,38 @@
+package com.smore.product.service;
+
+import com.smore.product.domain.dto.CreateProductRequest;
+import com.smore.product.domain.dto.ProductResponse;
+import com.smore.product.domain.entity.Product;
+import com.smore.product.domain.entity.SaleType;
+import com.smore.product.domain.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    public ProductResponse createProduct(CreateProductRequest req) {
+
+        if (req.getSaleType() == SaleType.LIMITED_TO_AUCTION
+                && req.getThresholdForAuction() == null) {
+            throw new IllegalArgumentException("LIMITED_TO_AUCTION requires thresholdForAuction");
+        }
+
+        Product p = Product.builder()
+                .sellerId(req.getSellerId())
+                .categoryId(req.getCategoryId())
+                .name(req.getName())
+                .description(req.getDescription())
+                .price(req.getPrice())
+                .stock(req.getStock())
+                .saleType(req.getSaleType())
+                .thresholdForAuction(req.getThresholdForAuction())
+                .build();
+
+        productRepository.save(p);
+
+        return new ProductResponse(p);
+    }
+}

--- a/product/src/main/resources/application.properties
+++ b/product/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=product

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+server:
+  port: 8800
+
+spring:
+
+  cloud:
+    config:
+      enabled: false
+
+  application:
+    name: product-service
+  datasource:
+    url: jdbc:postgresql://localhost:5432/product-db
+    username: root
+    password: root
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true


### PR DESCRIPTION
상품 도메인에서 신규 상품 생성 기능을 추가했습니다.
판매자는 필수 정보 입력 후 상품을 등록할 수 있으며, 카테고리는 Category-Service의 ID 값을 참조합니다.

🧩 주요 내용
1️⃣ Product 생성 API 추가
POST /api/products
상품명, 가격, 재고, 판매유형(saleType), 카테고리 ID 등 입력받아 상품 생성
UUID 기반 ID 생성

2️⃣ Category-Service 연동
categoryId 유효성 검증을 위해 Category-Service에 요청
존재하지 않는 카테고리일 경우 예외 처리

3️⃣ 도메인 로직 구현
Product Entity 생성
ProductRepository 저장 로직 구현
ProductService에서 생성 흐름 완성

4️⃣ DTO 구성
ProductCreateRequest
ProductResponse