### PR TITLE
Order 주문 완료, Outbox 폴링 처리기, 이벤트 리스너 구현

### DIFF
--- a/order/src/main/java/com/smore/order/OrderApplication.java
+++ b/order/src/main/java/com/smore/order/OrderApplication.java
@@ -3,7 +3,9 @@ package com.smore.order;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class OrderApplication {

--- a/order/src/main/java/com/smore/order/application/command/CompletedOrderCommand.java
+++ b/order/src/main/java/com/smore/order/application/command/CompletedOrderCommand.java
@@ -1,0 +1,42 @@
+package com.smore.order.application.command;
+
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.OutboxResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Slf4j(topic = "CreatedOrderCommand")
+public class CompletedOrderCommand implements OutboxCommand{
+
+    private final String topic;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Outbox outbox;
+
+    public CompletedOrderCommand(String topic, KafkaTemplate<String, String> kafkaTemplate, Outbox outbox) {
+        this.topic = topic;
+        this.kafkaTemplate = kafkaTemplate;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public OutboxResult execute() {
+        log.info("CompletedOrder 이벤트 발행 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+            outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+        try {
+            kafkaTemplate.send(topic, outbox.getPayload())
+                .get();
+
+            log.info("CompletedOrder 이벤트 발행 성공 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+                outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+            return OutboxResult.SUCCESS;
+        } catch (Exception e) {
+
+            log.error("CompletedOrder 이벤트 발행 실패 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+                outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+            return OutboxResult.FAIL;
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/application/command/CompletedOrderCommand.java
+++ b/order/src/main/java/com/smore/order/application/command/CompletedOrderCommand.java
@@ -5,7 +5,7 @@ import com.smore.order.domain.status.OutboxResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 
-@Slf4j(topic = "CreatedOrderCommand")
+@Slf4j(topic = "CompletedOrderCommand")
 public class CompletedOrderCommand implements OutboxCommand{
 
     private final String topic;

--- a/order/src/main/java/com/smore/order/application/command/CreatedOrderCommand.java
+++ b/order/src/main/java/com/smore/order/application/command/CreatedOrderCommand.java
@@ -1,0 +1,43 @@
+package com.smore.order.application.command;
+
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.OutboxResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Slf4j(topic = "CreatedOrderCommand")
+public class CreatedOrderCommand implements OutboxCommand {
+
+    @Value("${topic.order.created}")
+    private String topic;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Outbox outbox;
+
+    public CreatedOrderCommand(KafkaTemplate<String, String> kafkaTemplate, Outbox outbox) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public OutboxResult execute() {
+        log.info("OrderService 이벤트 발행 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+            outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+        try {
+            kafkaTemplate.send(topic, outbox.getPayload())
+                .get();
+
+            log.info("OrderService 이벤트 발행 성공 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+                outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+            return OutboxResult.SUCCESS;
+        } catch (Exception e) {
+
+            log.error("OrderService 이벤트 발행 실패 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+                outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+            return OutboxResult.FAIL;
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/application/command/CreatedOrderCommand.java
+++ b/order/src/main/java/com/smore/order/application/command/CreatedOrderCommand.java
@@ -3,18 +3,17 @@ package com.smore.order.application.command;
 import com.smore.order.domain.model.Outbox;
 import com.smore.order.domain.status.OutboxResult;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @Slf4j(topic = "CreatedOrderCommand")
 public class CreatedOrderCommand implements OutboxCommand {
 
-    @Value("${topic.order.created}")
-    private String topic;
+    private final String topic;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final Outbox outbox;
 
-    public CreatedOrderCommand(KafkaTemplate<String, String> kafkaTemplate, Outbox outbox) {
+    public CreatedOrderCommand(String topic, KafkaTemplate<String, String> kafkaTemplate, Outbox outbox) {
+        this.topic = topic;
         this.kafkaTemplate = kafkaTemplate;
         this.outbox = outbox;
     }

--- a/order/src/main/java/com/smore/order/application/command/OutboxCommand.java
+++ b/order/src/main/java/com/smore/order/application/command/OutboxCommand.java
@@ -1,0 +1,9 @@
+package com.smore.order.application.command;
+
+import com.smore.order.domain.status.OutboxResult;
+
+public interface OutboxCommand {
+
+    OutboxResult execute();
+
+}

--- a/order/src/main/java/com/smore/order/application/factory/OutboxCommandFactory.java
+++ b/order/src/main/java/com/smore/order/application/factory/OutboxCommandFactory.java
@@ -1,9 +1,11 @@
 package com.smore.order.application.factory;
 
+import com.smore.order.application.command.CompletedOrderCommand;
 import com.smore.order.application.command.CreatedOrderCommand;
 import com.smore.order.application.command.OutboxCommand;
 import com.smore.order.domain.model.Outbox;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -13,10 +15,16 @@ public class OutboxCommandFactory {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
+    @Value("${topic.order.created}")
+    private String orderCreatedTopic;
+
+    @Value("${topic.order.completed}")
+    private String orderCompletedTopic;
+
     public OutboxCommand from(Outbox outbox) {
         return switch (outbox.getEventType()) {
-            case ORDER_CREATED -> new CreatedOrderCommand(kafkaTemplate, outbox);
-            case ORDER_COMPLETED -> null;
+            case ORDER_CREATED -> new CreatedOrderCommand(orderCreatedTopic, kafkaTemplate, outbox);
+            case ORDER_COMPLETED -> new CompletedOrderCommand(orderCompletedTopic, kafkaTemplate, outbox);
             case ORDER_FAILED -> null;
             case PAYMENT_CANCEL -> null;
             case ORDER_CANCELLED -> null;

--- a/order/src/main/java/com/smore/order/application/factory/OutboxCommandFactory.java
+++ b/order/src/main/java/com/smore/order/application/factory/OutboxCommandFactory.java
@@ -1,0 +1,28 @@
+package com.smore.order.application.factory;
+
+import com.smore.order.application.command.CreatedOrderCommand;
+import com.smore.order.application.command.OutboxCommand;
+import com.smore.order.domain.model.Outbox;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxCommandFactory {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public OutboxCommand from(Outbox outbox) {
+        return switch (outbox.getEventType()) {
+            case ORDER_CREATED -> new CreatedOrderCommand(kafkaTemplate, outbox);
+            case ORDER_COMPLETED -> null;
+            case ORDER_FAILED -> null;
+            case PAYMENT_CANCEL -> null;
+            case ORDER_CANCELLED -> null;
+            default -> throw new IllegalArgumentException(
+                "지원되지 않은 이벤트입니다." + outbox.getEventType()
+            );
+        };
+    }
+}

--- a/order/src/main/java/com/smore/order/application/listener/EventListener.java
+++ b/order/src/main/java/com/smore/order/application/listener/EventListener.java
@@ -1,0 +1,37 @@
+package com.smore.order.application.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.order.application.service.OrderService;
+import com.smore.order.domain.event.CompletedPaymentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "EventListener")
+@Component
+@RequiredArgsConstructor
+public class EventListener {
+
+    private final OrderService service;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+        topics = "${topic.payment.completed}",
+        groupId = "${consumer.group.payment}",
+        concurrency = "3"
+    )
+    public void paymentCompleted(String message, Acknowledgment ack) {
+        try {
+            CompletedPaymentEvent event = objectMapper.readValue(message,
+                CompletedPaymentEvent.class);
+
+            service.completeOrder(event.getOrderId());
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("PaymentCompleted 처리 실패 : {}", message, e);
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/application/listener/EventListener.java
+++ b/order/src/main/java/com/smore/order/application/listener/EventListener.java
@@ -1,7 +1,10 @@
 package com.smore.order.application.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.order.application.command.CompletedOrderCommand;
+import com.smore.order.application.dto.CreateOrderCommand;
 import com.smore.order.application.service.OrderService;
+import com.smore.order.domain.event.BidRequestEvent;
 import com.smore.order.domain.event.CompletedPaymentEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +19,37 @@ public class EventListener {
 
     private final OrderService service;
     private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+        topics = "${topic.bid.order.request}",
+        groupId = "${consumer.group.bid}",
+        concurrency = "3"
+    )
+    public void bidRequest(String message, Acknowledgment ack) {
+        try {
+
+            BidRequestEvent event = objectMapper.readValue(message,
+                BidRequestEvent.class);
+
+            CreateOrderCommand command = CreateOrderCommand.create(
+                event.getUserId(),
+                event.getProductId(),
+                event.getProductPrice(),
+                event.getQuantity(),
+                event.getIdempotencyKey(),
+                event.getExpiresAt(),
+                event.getStreet(),
+                event.getCity(),
+                event.getZipcode()
+            );
+
+            service.createOrder(command);
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("BidRequest 처리 실패 : {}", message, e);
+        }
+    }
 
     @KafkaListener(
         topics = "${topic.payment.completed}",

--- a/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
@@ -9,4 +9,8 @@ public interface OrderRepository {
 
     Order save(Order order);
 
+    int markComplete(UUID orderId);
+
+    Order findById(UUID orderId);
+
 }

--- a/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
@@ -2,6 +2,9 @@ package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Outbox;
 import com.smore.order.domain.status.EventStatus;
+import java.util.Collection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OutboxRepository {
 
@@ -17,4 +20,5 @@ public interface OutboxRepository {
 
     int makeFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
 
+    Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
 }

--- a/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
@@ -1,11 +1,20 @@
 package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.EventStatus;
 
 public interface OutboxRepository {
 
     Outbox save(Outbox outbox);
 
     Outbox findById(Long outboxId);
+
+    int claim(Long outboxId, EventStatus eventStatus);
+
+    int markSent(Long outboxId, EventStatus eventStatus);
+
+    int makeRetry(Long outboxId, EventStatus eventStatus);
+
+    int makeFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
 
 }

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -37,7 +37,7 @@ public class OrderService {
     public void createOrder(CreateOrderCommand command) {
 
         Order findOrder = orderRepository.findByIdempotencyKey(command.getIdempotencyKey());
-        if (findOrder == null) {
+        if (findOrder != null) {
             return;
         }
 

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -5,11 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smore.order.application.dto.CreateOrderCommand;
 import com.smore.order.application.repository.OrderRepository;
 import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.domain.event.CompletedOrderEvent;
 import com.smore.order.domain.event.CreatedOrderEvent;
+import com.smore.order.domain.event.OrderEvent;
 import com.smore.order.domain.model.Order;
 import com.smore.order.domain.model.Outbox;
 import com.smore.order.domain.status.AggregateType;
 import com.smore.order.domain.status.EventType;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.domain.status.ServiceResult;
+import com.smore.order.infrastructure.persistence.exception.CompleteOrderFailException;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -71,7 +76,46 @@ public class OrderService {
         outboxRepository.save(outbox);
     }
 
-    private String makePayload(CreatedOrderEvent event)  {
+    @Transactional
+    public ServiceResult completeOrder(UUID orderId) {
+
+        Order order = orderRepository.findById(orderId);
+
+        if (order.isCompleted()) {
+            log.info("이미 처리된 작업 orderId : {}", orderId);
+            return ServiceResult.SUCCESS;
+        }
+
+        int updated = orderRepository.markComplete(orderId);
+
+        if (updated == 0) {
+            log.error("주문 완료 상태로 변경하지 못했습니다. orderId = {}, methodName = {}", orderId, "completeOrder");
+            throw new CompleteOrderFailException("주문 완료 상태로 변경하지 못했습니다.");
+        }
+
+        CompletedOrderEvent event = CompletedOrderEvent.of(
+            order.getId(),
+            order.getUserId(),
+            OrderStatus.COMPLETED,
+            UUID.randomUUID(),
+            LocalDateTime.now(clock)
+        );
+
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            order.getId(),
+            EventType.ORDER_COMPLETED,
+            UUID.randomUUID(),
+            makePayload(event)
+        );
+
+        outboxRepository.save(outbox);
+
+        return ServiceResult.SUCCESS;
+    }
+
+    // TODO: 나중에 클래스로 분리할 예정
+    private String makePayload(OrderEvent event)  {
         try {
             return objectMapper.writeValueAsString(event);
         } catch (JsonProcessingException e) {

--- a/order/src/main/java/com/smore/order/application/service/OutboxProcessor.java
+++ b/order/src/main/java/com/smore/order/application/service/OutboxProcessor.java
@@ -22,14 +22,14 @@ public class OutboxProcessor {
     private final OutboxRepository outboxRepository;
     private final OutboxCommandFactory factory;
 
-    public void outboxProcessor(Outbox outbox) {
+    public void outboxProcessor(Long outboxId) {
 
-        int updated = outboxRepository.claim(outbox.getId(), EventStatus.PROCESSING);
+        int updated = outboxRepository.claim(outboxId, EventStatus.PROCESSING);
         if (updated == 0) {
             return;
         }
 
-        Outbox fresh = outboxRepository.findById(outbox.getId());
+        Outbox fresh = outboxRepository.findById(outboxId);
 
         if (fresh.isExceededRetry(maxRetryCount)) {
             int result = outboxRepository.makeFail(fresh.getId(), EventStatus.FAILED, maxRetryCount);

--- a/order/src/main/java/com/smore/order/application/service/OutboxProcessor.java
+++ b/order/src/main/java/com/smore/order/application/service/OutboxProcessor.java
@@ -1,0 +1,64 @@
+package com.smore.order.application.service;
+
+import com.smore.order.application.factory.OutboxCommandFactory;
+import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.application.command.OutboxCommand;
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.EventStatus;
+import com.smore.order.domain.status.OutboxResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j(topic = "OutboxProcessor")
+@Service
+@RequiredArgsConstructor
+public class OutboxProcessor {
+
+    @Value("${retry.count.max}")
+    private Integer maxRetryCount;
+
+    private final OutboxRepository outboxRepository;
+    private final OutboxCommandFactory factory;
+
+    public void outboxProcessor(Outbox outbox) {
+
+        int updated = outboxRepository.claim(outbox.getId(), EventStatus.PROCESSING);
+        if (updated == 0) {
+            return;
+        }
+
+        Outbox fresh = outboxRepository.findById(outbox.getId());
+
+        if (fresh.isExceededRetry(maxRetryCount)) {
+            int result = outboxRepository.makeFail(fresh.getId(), EventStatus.FAILED, maxRetryCount);
+            if (result == 0) {
+                log.error("재시도 횟수 초과 후, outbox 상태 전환 실패 outboxId : {}, domain : {}, eventType : {}",
+                    fresh.getId(), fresh.getAggregateType(), fresh.getEventType());
+            }
+            return;
+        }
+
+        OutboxCommand command = factory.from(fresh);
+        OutboxResult result = command.execute();
+
+        // FIXME : 선점 상태이므로 상태 전이가 적용되지 않는다면 영원히 PROGRESS 상태가 됨 이에 대한 후속 처리 필요
+        if (result == OutboxResult.SUCCESS) {
+            updated = outboxRepository.markSent(fresh.getId(), EventStatus.SENT);
+            if (updated == 0) {
+                log.error("카프카에 이벤트 발행 후, outbox 상태 전환 실패 outboxId : {}, domain : {}, eventType : {}",
+                    fresh.getId(), fresh.getAggregateType(), fresh.getEventType());
+                return;
+            }
+        } else {
+            updated = outboxRepository.makeRetry(fresh.getId(), EventStatus.PENDING);
+            if (updated == 0) {
+                log.error("카프카에 이벤트 발행 실패 후, outbox 상태 전환 실패 outboxId : {}, domain : {}, eventType : {}",
+                    fresh.getId(), fresh.getAggregateType(), fresh.getEventType());
+                return;
+            }
+        }
+    }
+
+}

--- a/order/src/main/java/com/smore/order/application/service/OutboxProcessor.java
+++ b/order/src/main/java/com/smore/order/application/service/OutboxProcessor.java
@@ -9,6 +9,7 @@ import com.smore.order.domain.status.OutboxResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Slf4j(topic = "OutboxProcessor")
@@ -22,6 +23,7 @@ public class OutboxProcessor {
     private final OutboxRepository outboxRepository;
     private final OutboxCommandFactory factory;
 
+    @Async("taskExecutor")
     public void outboxProcessor(Long outboxId) {
 
         int updated = outboxRepository.claim(outboxId, EventStatus.PROCESSING);

--- a/order/src/main/java/com/smore/order/domain/event/BidRequestEvent.java
+++ b/order/src/main/java/com/smore/order/domain/event/BidRequestEvent.java
@@ -1,0 +1,25 @@
+package com.smore.order.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BidRequestEvent {
+
+    private Long userId;
+    private UUID productId;
+    private Integer productPrice;
+    private Integer quantity;
+    private UUID idempotencyKey;
+    private LocalDateTime expiresAt;
+    private String street;
+    private String city;
+    private String zipcode;
+
+}

--- a/order/src/main/java/com/smore/order/domain/event/CompletedOrderEvent.java
+++ b/order/src/main/java/com/smore/order/domain/event/CompletedOrderEvent.java
@@ -1,0 +1,35 @@
+package com.smore.order.domain.event;
+
+import com.smore.order.domain.status.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompletedOrderEvent implements OrderEvent {
+
+    private final UUID orderId;
+    private final Long userId;
+    private final OrderStatus currentOrderStatus;
+    private final UUID idempotencyKey;
+    private final LocalDateTime publishedAt;
+
+    public static CompletedOrderEvent of(
+        UUID orderId, Long userId, OrderStatus currentOrderStatus, UUID idempotencyKey,
+        LocalDateTime now) {
+
+        return CompletedOrderEvent.builder()
+            .orderId(orderId)
+            .userId(userId)
+            .currentOrderStatus(currentOrderStatus)
+            .idempotencyKey(idempotencyKey)
+            .publishedAt(now)
+            .build();
+    }
+
+}

--- a/order/src/main/java/com/smore/order/domain/event/CompletedPaymentEvent.java
+++ b/order/src/main/java/com/smore/order/domain/event/CompletedPaymentEvent.java
@@ -1,0 +1,11 @@
+package com.smore.order.domain.event;
+
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CompletedPaymentEvent {
+    // TODO: Payment와 협의하여 어떤 데이터를 줄 것인지에 따라 구현해야 함
+    private UUID orderId;
+
+}

--- a/order/src/main/java/com/smore/order/domain/event/CreatedOrderEvent.java
+++ b/order/src/main/java/com/smore/order/domain/event/CreatedOrderEvent.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 @Builder(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class CreatedOrderEvent {
+public class CreatedOrderEvent implements OrderEvent{
 
     private final UUID orderId;
     private final Long userId;

--- a/order/src/main/java/com/smore/order/domain/event/OrderEvent.java
+++ b/order/src/main/java/com/smore/order/domain/event/OrderEvent.java
@@ -1,0 +1,5 @@
+package com.smore.order.domain.event;
+
+public interface OrderEvent {
+
+}

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -56,7 +56,7 @@ public class Order {
             .quantity(quantity)
             .totalAmount(totalAmount)
             .idempotencyKey(idempotencyKey)
-            .orderStatus(OrderStatus.CRATED)
+            .orderStatus(OrderStatus.CREATED)
             .cancelState(CancelState.NONE)
             .orderedAt(now)
             .address(address)
@@ -102,6 +102,10 @@ public class Order {
             .cancelledAt(cancelledAt)
             .address(address)
             .build();
+    }
+
+    public boolean isCompleted() {
+        return orderStatus == OrderStatus.COMPLETED;
     }
 
     private static Integer calculateTotalPrice(Integer price, Integer quantity) {

--- a/order/src/main/java/com/smore/order/domain/model/Outbox.java
+++ b/order/src/main/java/com/smore/order/domain/model/Outbox.java
@@ -77,4 +77,8 @@ public class Outbox {
             .build();
     }
 
+    public boolean isExceededRetry(Integer maxRetryCount) {
+        return retryCount >= maxRetryCount;
+    }
+
 }

--- a/order/src/main/java/com/smore/order/domain/model/Outbox.java
+++ b/order/src/main/java/com/smore/order/domain/model/Outbox.java
@@ -26,6 +26,8 @@ public class Outbox {
 
     private String payload;
 
+    private Integer retryCount;
+
     private EventStatus eventStatus;
 
     public static Outbox create(
@@ -47,6 +49,7 @@ public class Outbox {
             .eventType(eventType)
             .idempotencyKey(idempotencyKey)
             .payload(payload)
+            .retryCount(0)
             .eventStatus(EventStatus.PENDING)
             .build();
     }
@@ -58,6 +61,7 @@ public class Outbox {
         EventType eventType,
         UUID idempotencyKey,
         String payload,
+        Integer retryCount,
         EventStatus eventStatus
     ) {
 
@@ -68,6 +72,7 @@ public class Outbox {
             .eventType(eventType)
             .idempotencyKey(idempotencyKey)
             .payload(payload)
+            .retryCount(retryCount)
             .eventStatus(eventStatus)
             .build();
     }

--- a/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
+++ b/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
@@ -1,7 +1,7 @@
 package com.smore.order.domain.status;
 
 public enum OrderStatus {
-    CRATED("주문 생성"),
+    CREATED("주문 생성"),
     COMPLETED("주문 완료"),
     FAILED("주문 실패"),
     CANCELLED("주문 취소")

--- a/order/src/main/java/com/smore/order/domain/status/OutboxResult.java
+++ b/order/src/main/java/com/smore/order/domain/status/OutboxResult.java
@@ -1,0 +1,13 @@
+package com.smore.order.domain.status;
+
+public enum OutboxResult {
+    SUCCESS("메시지 발행 성공"),
+    FAIL("메시지 발행 실패")
+    ;
+
+    private final String description;
+
+    OutboxResult(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/domain/status/ServiceResult.java
+++ b/order/src/main/java/com/smore/order/domain/status/ServiceResult.java
@@ -1,0 +1,13 @@
+package com.smore.order.domain.status;
+
+public enum ServiceResult {
+    SUCCESS("서비스 작업 완료"),
+    FAIL("서비스 작업 실패")
+    ;
+
+    private final String description;
+
+    ServiceResult(String description) {
+        this.description = description;
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/config/AsyncConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.smore.order.infrastructure.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    /**
+     * 단기 급격한 트래픽 설정
+     * 평소에는 적은 스레드로 리소스 절약
+     * 최대 스레드 수를 높게 설정하여 트래픽 급증 시 빠르게 확장 가능
+     * 대기열을 작게 하여 대기열이 빨리 차서 새 스레드 생성을 촉진
+     */
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(100);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("task-worker");
+        executor.initialize();
+
+        return executor;
+    }
+
+}

--- a/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,22 @@
+package com.smore.order.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${topic.order.created}")
+    private String createdOrderTopic;
+
+    @Bean
+    public NewTopic orderCreatedTopic() {
+        return TopicBuilder.name(createdOrderTopic)
+            .partitions(3)
+            .replicas(1)
+            .build();
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
@@ -16,7 +16,7 @@ public class KafkaConfig {
     public NewTopic orderCreatedTopic() {
         return TopicBuilder.name(createdOrderTopic)
             .partitions(3)
-            .replicas(1)
+            .replicas(3)
             .build();
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/order/OrderEntity.java
@@ -93,7 +93,7 @@ public class OrderEntity extends BaseEntity {
         if (quantity == null)throw new IllegalArgumentException("주문 수량은 필수값입니다.");
         if (quantity < 1)throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다.");
         if (idempotencyKey == null) throw new IllegalArgumentException("멱등키는 필수입니다.");
-        if (orderStatus != OrderStatus.CRATED) throw new IllegalArgumentException("주문 생성 시 OrderStatus의 상태는 CREATED 상태여야 합니다.");
+        if (orderStatus != OrderStatus.CREATED) throw new IllegalArgumentException("주문 생성 시 OrderStatus의 상태는 CREATED 상태여야 합니다.");
         if (cancelState != CancelState.NONE) throw new IllegalArgumentException("주문 생성 시 CancelStatus의 상태는 NONE 상태여야 합니다.");
         if (orderedAt == null) throw new IllegalArgumentException("현재 날짜는 필수입니다.");
 

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/entity/outbox/OutboxEntity.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/entity/outbox/OutboxEntity.java
@@ -48,6 +48,8 @@ public class OutboxEntity extends BaseEntity {
 
     private String payload;
 
+    private Integer retryCount;
+
     @Enumerated(EnumType.STRING)
     private EventStatus eventStatus;
 
@@ -57,6 +59,7 @@ public class OutboxEntity extends BaseEntity {
         EventType eventType,
         UUID idempotencyKey,
         String payload,
+        Integer retryCount,
         EventStatus eventStatus
     ) {
 
@@ -71,6 +74,7 @@ public class OutboxEntity extends BaseEntity {
             .eventType(eventType)
             .idempotencyKey(idempotencyKey)
             .payload(payload)
+            .retryCount(retryCount)
             .eventStatus(eventStatus)
             .build();
     }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/exception/CompleteOrderFailException.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/exception/CompleteOrderFailException.java
@@ -1,0 +1,8 @@
+package com.smore.order.infrastructure.persistence.exception;
+
+public class CompleteOrderFailException extends RuntimeException {
+
+    public CompleteOrderFailException(String message) {
+        super(message);
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/exception/NotFoundOrderException.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/exception/NotFoundOrderException.java
@@ -1,0 +1,8 @@
+package com.smore.order.infrastructure.persistence.exception;
+
+public class NotFoundOrderException extends RuntimeException {
+
+    public NotFoundOrderException(String message) {
+        super(message);
+    }
+}

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OutboxMapper.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OutboxMapper.java
@@ -20,6 +20,7 @@ public final class OutboxMapper {
             outbox.getEventType(),
             outbox.getIdempotencyKey(),
             outbox.getPayload(),
+            outbox.getRetryCount(),
             outbox.getEventStatus()
         );
     }
@@ -36,6 +37,7 @@ public final class OutboxMapper {
             entity.getEventType(),
             entity.getIdempotencyKey(),
             entity.getPayload(),
+            entity.getRetryCount(),
             entity.getEventStatus()
         );
     }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.smore.order.infrastructure.persistence.repository.order;
 
+import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import java.util.UUID;
 
 public interface OrderJpaRepositoryCustom {
 
     OrderEntity findByIdempotencyKey(UUID idempotencyKey);
+
+    int markComplete(UUID orderId, OrderStatus status);
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
@@ -3,11 +3,11 @@ package com.smore.order.infrastructure.persistence.repository.order;
 import static com.smore.order.infrastructure.persistence.entity.order.QOrderEntity.*;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import jakarta.persistence.EntityManager;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
@@ -24,5 +24,22 @@ public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
                 orderEntity.idempotencyKey.eq(idempotencyKey)
             )
             .fetchOne();
+    }
+
+    @Override
+    public int markComplete(UUID orderId, OrderStatus status) {
+         long updated = queryFactory
+            .update(orderEntity)
+            .set(orderEntity.orderStatus, status)
+            .where(
+                orderEntity.id.eq(orderId),
+                orderEntity.orderStatus.eq(OrderStatus.CREATED)
+            )
+            .execute();
+
+        em.flush();
+        em.clear();
+
+        return (int) updated;
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
@@ -2,13 +2,16 @@ package com.smore.order.infrastructure.persistence.repository.order;
 
 import com.smore.order.application.repository.OrderRepository;
 import com.smore.order.domain.model.Order;
+import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOrderFailException;
+import com.smore.order.infrastructure.persistence.exception.NotFoundOrderException;
 import com.smore.order.infrastructure.persistence.mapper.OrderMapper;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j(topic = "OrderRepositoryImpl")
 @Repository
@@ -46,6 +49,33 @@ public class OrderRepositoryImpl implements OrderRepository {
             log.error("entity is Null : methodName = {}", "save()");
             throw new CreateOrderFailException("주문이 생성되지 않았습니다.");
         }
+        return OrderMapper.toDomain(entity);
+    }
+
+    @Override
+    public int markComplete(UUID orderId) {
+
+        if (orderId == null) {
+            log.error("orderId is Null : methodName = {}", "markComplete()");
+            throw new IllegalArgumentException("주문 아이디가 null 입니다.");
+        }
+
+        return orderJpaRepository.markComplete(orderId, OrderStatus.COMPLETED);
+    }
+
+    @Override
+    public Order findById(UUID orderId) {
+
+        if (orderId == null) {
+            log.error("orderId is Null : methodName = {}", "markComplete()");
+            throw new IllegalArgumentException("주문 아이디가 null 입니다.");
+        }
+
+        OrderEntity entity = orderJpaRepository.findById(orderId)
+            .orElseThrow(
+                () -> new NotFoundOrderException("주문을 찾을 수 없습니다.")
+            );
+
         return OrderMapper.toDomain(entity);
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,6 +1,9 @@
 package com.smore.order.infrastructure.persistence.repository.outbox;
 
 import com.smore.order.domain.status.EventStatus;
+import java.util.Collection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OutboxJpaRepositoryCustom {
 
@@ -11,5 +14,7 @@ public interface OutboxJpaRepositoryCustom {
     int makeRetry(Long outboxId, EventStatus eventStatus);
 
     int makeFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,5 +1,15 @@
 package com.smore.order.infrastructure.persistence.repository.outbox;
 
+import com.smore.order.domain.status.EventStatus;
+
 public interface OutboxJpaRepositoryCustom {
+
+    int claim(Long outboxId, EventStatus eventStatus);
+
+    int markSent(Long outboxId, EventStatus eventStatus);
+
+    int makeRetry(Long outboxId, EventStatus eventStatus);
+
+    int makeFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
@@ -1,5 +1,87 @@
 package com.smore.order.infrastructure.persistence.repository.outbox;
 
+import static com.smore.order.infrastructure.persistence.entity.outbox.QOutboxEntity.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import com.smore.order.domain.status.EventStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom {
 
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public int claim(Long outboxId, EventStatus eventStatus) {
+
+        long updated = queryFactory
+            .update(outboxEntity)
+            .set(outboxEntity.eventStatus, eventStatus)
+            .where(
+                outboxEntity.id.eq(outboxId),
+                outboxEntity.eventStatus.eq(EventStatus.PENDING)
+            )
+            .execute();
+
+        em.flush();
+        em.clear();
+
+        return (int) updated;
+    }
+
+    @Override
+    public int markSent(Long outboxId, EventStatus eventStatus) {
+        long updated = queryFactory
+            .update(outboxEntity)
+            .set(outboxEntity.eventStatus, eventStatus)
+            .where(
+                outboxEntity.id.eq(outboxId),
+                outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
+            )
+            .execute();
+
+        em.flush();
+        em.clear();
+
+        return (int) updated;
+    }
+
+    @Override
+    public int makeRetry(Long outboxId, EventStatus eventStatus) {
+        long updated = queryFactory
+            .update(outboxEntity)
+            .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.retryCount, outboxEntity.retryCount.add(1))
+            .where(
+                outboxEntity.id.eq(outboxId),
+                outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
+            )
+            .execute();
+
+        em.flush();
+        em.clear();
+
+        return (int) updated;
+    }
+
+    @Override
+    public int makeFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount) {
+        long updated = queryFactory
+            .update(outboxEntity)
+            .set(outboxEntity.eventStatus, eventStatus)
+            .where(
+                outboxEntity.id.eq(outboxId),
+                outboxEntity.eventStatus.eq(EventStatus.PROCESSING),
+                outboxEntity.retryCount.goe(maxRetryCount)
+            )
+            .execute();
+
+        em.flush();
+        em.clear();
+
+        return (int) updated;
+    }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -7,8 +7,11 @@ import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOutboxFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOutboxException;
 import com.smore.order.infrastructure.persistence.mapper.OutboxMapper;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -103,5 +106,21 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.makeFail(outboxId, eventStatus, maxRetryCount);
+    }
+
+    @Override
+    public Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable) {
+
+        if (states == null || states.isEmpty()) {
+            log.error("states가 유효하지 않습니다. : method = {}", "findPendingIds()");
+            throw new IllegalArgumentException("states가 유효하지 않습니다.");
+        }
+
+        if (pageable == null) {
+            log.error("pageable이 유효하지 않습니다. : method = {}", "findPendingIds()");
+            throw new IllegalArgumentException("pageable이 유효하지 않습니다.");
+        }
+
+        return outboxJpaRepository.findPendingIds(states, pageable);
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.smore.order.infrastructure.persistence.repository.outbox;
 
 import com.smore.order.application.repository.OutboxRepository;
 import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.EventStatus;
 import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOutboxFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOutboxException;
@@ -9,6 +10,7 @@ import com.smore.order.infrastructure.persistence.mapper.OutboxMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j(topic = "OutboxRepositoryImpl")
 @Repository
@@ -25,7 +27,7 @@ public class OutboxRepositoryImpl implements OutboxRepository {
             throw new IllegalArgumentException("outbox null입니다.");
         }
 
-         OutboxEntity entity = outboxJpaRepository.save(
+        OutboxEntity entity = outboxJpaRepository.save(
             OutboxMapper.toEntityForCreate(outbox));
 
         if (entity == null) {
@@ -50,4 +52,56 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         return OutboxMapper.toDomain(entity);
     }
 
+    @Transactional
+    @Override
+    public int claim(Long outboxId, EventStatus eventStatus) {
+
+        if (outboxId == null) {
+            log.error("outboxId is Null : method = {}", "claim()");
+            throw new IllegalArgumentException("outboxId가 null입니다.");
+        }
+
+        return outboxJpaRepository.claim(outboxId, eventStatus);
+    }
+
+    @Transactional
+    @Override
+    public int markSent(Long outboxId, EventStatus eventStatus) {
+
+        if (outboxId == null) {
+            log.error("outboxId is Null : method = {}", "claim()");
+            throw new IllegalArgumentException("outboxId가 null입니다.");
+        }
+
+        return outboxJpaRepository.markSent(outboxId, eventStatus);
+    }
+
+    @Transactional
+    @Override
+    public int makeRetry(Long outboxId, EventStatus eventStatus) {
+
+        if (outboxId == null) {
+            log.error("outboxId is Null : method = {}", "makeRetry()");
+            throw new IllegalArgumentException("outboxId가 null입니다.");
+        }
+
+        return outboxJpaRepository.makeRetry(outboxId, eventStatus);
+    }
+
+    @Transactional
+    @Override
+    public int makeFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount) {
+
+        if (outboxId == null) {
+            log.error("outboxId is Null : method = {}", "claim()");
+            throw new IllegalArgumentException("outboxId가 null입니다.");
+        }
+
+        if (maxRetryCount == null || maxRetryCount < 1) {
+            log.error("maxRetryCount is Null : method = {}", "makeFail()");
+            throw new IllegalArgumentException("maxRetryCount 값은 필수이며 양수여야 합니다.");
+        }
+
+        return outboxJpaRepository.makeFail(outboxId, eventStatus, maxRetryCount);
+    }
 }

--- a/order/src/main/java/com/smore/order/presentation/scheduler/OutboxScheduler.java
+++ b/order/src/main/java/com/smore/order/presentation/scheduler/OutboxScheduler.java
@@ -1,0 +1,53 @@
+package com.smore.order.presentation.scheduler;
+
+import com.smore.order.application.repository.OutboxRepository;
+import com.smore.order.application.service.OutboxProcessor;
+import com.smore.order.domain.status.EventStatus;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j(topic = "OutboxScheduler")
+@Service
+@RequiredArgsConstructor
+public class OutboxScheduler {
+
+    private final OutboxRepository outboxRepository;
+    private final OutboxProcessor processor;
+
+    private static final Set<EventStatus> PROCESSING_STATES = Set.of(
+        EventStatus.PENDING
+    );
+
+    @Scheduled(fixedDelay = 100)
+    public void outboxTasks() {
+        int page = 0;
+        int pageSize = 100;
+
+        while (true) {
+            Page<Long> taskIds = outboxRepository.findPendingIds(
+                PROCESSING_STATES,
+                PageRequest.of(page, pageSize)
+            );
+
+            if (!taskIds.hasContent()) break;
+
+            for (Long outboxId : taskIds) {
+                try {
+                    processor.outboxProcessor(outboxId);
+                } catch (Exception e) {
+                    log.error("task 스케줄러 작업 위임 실패 {}", outboxId, e);
+                }
+            }
+
+            if (!taskIds.hasNext()) break;
+            page++;
+        }
+    }
+}

--- a/order/src/main/resources/application.properties
+++ b/order/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=order

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -30,7 +30,7 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
       # 컨슈머 그룹 ID (서비스 단위로 나눠서)
-      group-id: my-api-service-group
+      group-id: order-service-consumer-group
 
       # 처음 시작 시 어디서부터 읽을지
       auto-offset-reset: earliest   # 필요에 따라 latest 로 변경 가능

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -41,6 +41,17 @@ spring:
 topic:
   order:
     created: order.created
+    completed: order.completed
+
+
+
+  payment:
+    completed: payment.completed
+
+consumer:
+  group:
+    payment: payment-completed-consumer-group
+
 
 retry:
   count:

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+spring:
+  application:
+    name: order-service
+
+
+  config:
+    import: ""           # configserver import 완전 해제
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+
+  kafka:
+    bootstrap-servers: localhost:19092,localhost:29092,localhost:39092
+
+    # 기본 직렬화/역직렬화 설정 (문자열)
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+      # 신뢰성 관련 (acks=all + 재시도 + idempotence)
+      acks: all
+      retries: 10
+      properties:
+        enable.idempotence: true
+
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+      # 컨슈머 그룹 ID (서비스 단위로 나눠서)
+      group-id: my-api-service-group
+
+      # 처음 시작 시 어디서부터 읽을지
+      auto-offset-reset: earliest   # 필요에 따라 latest 로 변경 가능
+
+      # 자동 커밋 끄고 수동 커밋으로 가는 것도 실무에서 많이 씀
+      enable-auto-commit: false
+
+topic:
+  order:
+    created: order.created
+
+retry:
+  count:
+    max: 5

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -43,14 +43,17 @@ topic:
     created: order.created
     completed: order.completed
 
-
+  bid:
+    order:
+      request: bid.order.request
 
   payment:
     completed: payment.completed
 
 consumer:
   group:
-    payment: payment-completed-consumer-group
+    payment: payment-consumer-group
+    bid: bid-consumer-group
 
 
 retry:

--- a/order/src/test/java/com/smore/order/application/service/OrderServiceTest.java
+++ b/order/src/test/java/com/smore/order/application/service/OrderServiceTest.java
@@ -63,8 +63,20 @@ class OrderServiceTest {
             "06234"
         );
 
+        Order order = Order.create(
+            1L,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            10_000,
+            2,
+            UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            LocalDateTime.of(2025, 11, 30, 12, 0, 0),
+            "서울시 강남구 테헤란로 1",
+            "서울시",
+            "06234"
+        );
+
         Mockito.when(orderRepository.findByIdempotencyKey(command.getIdempotencyKey()))
-            .thenReturn(null);
+            .thenReturn(order);
 
         // when
         orderService.createOrder(command);
@@ -131,7 +143,7 @@ class OrderServiceTest {
             1L);
 
         Mockito.when(orderRepository.findByIdempotencyKey(command.getIdempotencyKey()))
-            .thenReturn(order);
+            .thenReturn(null);
 
         Mockito.when(orderRepository.save(Mockito.any(Order.class)))
             .thenReturn(order);

--- a/order/src/test/java/com/smore/order/domain/model/OrderTest.java
+++ b/order/src/test/java/com/smore/order/domain/model/OrderTest.java
@@ -431,7 +431,7 @@ class OrderTest {
         Assertions.assertThat(order.getTotalAmount()).isEqualTo(productPrice * quantity);
 
         Assertions.assertThat(order.getIdempotencyKey()).isEqualTo(idempotencyKey);
-        Assertions.assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CRATED);
+        Assertions.assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CREATED);
         Assertions.assertThat(order.getCancelState()).isEqualTo(CancelState.NONE);
 
         Assertions.assertThat(order.getOrderedAt()).isEqualTo(now);

--- a/order/src/test/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImplTest.java
+++ b/order/src/test/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.smore.order.application.repository.OutboxRepository;
 import com.smore.order.domain.model.Outbox;
 import com.smore.order.domain.status.AggregateType;
+import com.smore.order.domain.status.EventStatus;
 import com.smore.order.domain.status.EventType;
 import com.smore.order.infrastructure.config.JpaConfig;
 import jakarta.persistence.EntityManager;
@@ -60,6 +61,7 @@ class OutboxRepositoryImplTest {
         Assertions.assertThat(outbox.getAggregateType()).isEqualTo(aggregateType);
         Assertions.assertThat(outbox.getEventType()).isEqualTo(eventType);
         Assertions.assertThat(outbox.getIdempotencyKey()).isEqualTo(idempotencyKey);
+        Assertions.assertThat(outbox.getEventStatus()).isEqualTo(EventStatus.PENDING);
         Assertions.assertThat(outbox.getPayload()).isEqualTo(payload);
     }
 
@@ -71,6 +73,189 @@ class OutboxRepositoryImplTest {
                 () -> outboxRepository.save(null)
             ).isInstanceOf(IllegalArgumentException.class)
             .hasMessage("outbox null입니다.");
+    }
+
+    @DisplayName("선점 요청이 들어오면 EventStatus 값이 PROCESSING이 된다. ")
+    @Test
+    void claimTest() {
+        // given
+
+        Outbox outbox =  Outbox.create(
+            AggregateType.ORDER,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            EventType.ORDER_CREATED,
+            UUID.fromString("3f9b8c1d-4e7e-4c1a-a8fd-2a6a7f9c3b44"),
+            "Test Payload Data"
+        );
+
+        Outbox saveOutbox = outboxRepository.save(outbox);
+
+        // when
+        int result =  outboxRepository.claim(saveOutbox.getId(), EventStatus.PROCESSING);
+
+        Outbox fresh = outboxRepository.findById(saveOutbox.getId());
+
+        // then
+        Assertions.assertThat(result).isEqualTo(1);
+        Assertions.assertThat(fresh.getEventStatus()).isEqualTo(EventStatus.PROCESSING);
+    }
+
+    @DisplayName("선점 요청할 때 outboxId가 null인 경우 IllegalArgumentException가 발생하고 선점하지 못한다.")
+    @Test
+    void claimTestWithException() {
+        // when // then
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.claim(null, EventStatus.PROCESSING)
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("outboxId가 null입니다.");
+    }
+
+    @DisplayName("선점 후 markSent를 호출하면 EventStatus 값이 SENT가 된다.")
+    @Test
+    void markSentTest() {
+        // given
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            EventType.ORDER_CREATED,
+            UUID.fromString("3f9b8c1d-4e7e-4c1a-a8fd-2a6a7f9c3b44"),
+            "Test Payload Data"
+        );
+
+        Outbox saveOutbox = outboxRepository.save(outbox);
+
+        outboxRepository.claim(saveOutbox.getId(), EventStatus.PROCESSING);
+
+        // when
+        int result = outboxRepository.markSent(saveOutbox.getId(), EventStatus.SENT);
+        Outbox fresh = outboxRepository.findById(saveOutbox.getId());
+
+        // then
+        Assertions.assertThat(result).isEqualTo(1);
+        Assertions.assertThat(fresh.getEventStatus()).isEqualTo(EventStatus.SENT);
+    }
+
+    @DisplayName("markSent 호출할 때 outboxId가 null인 경우 IllegalArgumentException가 발생하고 상태를 변경하지 못한다.")
+    @Test
+    void markSentTestWithException() {
+        // when // then
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.markSent(null, EventStatus.SENT)
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("outboxId가 null입니다.");
+    }
+
+    @DisplayName("makeRetry를 호출하면 상태가 변경되고 retryCount가 1 증가한다.")
+    @Test
+    void makeRetryTest() {
+        // given
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            EventType.ORDER_CREATED,
+            UUID.fromString("3f9b8c1d-4e7e-4c1a-a8fd-2a6a7f9c3b44"),
+            "Test Payload Data"
+        );
+
+        Outbox saveOutbox = outboxRepository.save(outbox);
+
+        outboxRepository.claim(saveOutbox.getId(), EventStatus.PROCESSING);
+
+        Outbox before = outboxRepository.findById(saveOutbox.getId());
+        int beforeRetryCount = before.getRetryCount();
+
+        // when
+        int result = outboxRepository.makeRetry(saveOutbox.getId(), EventStatus.PROCESSING);
+
+        Outbox fresh = outboxRepository.findById(saveOutbox.getId());
+
+        // then
+        Assertions.assertThat(result).isEqualTo(1);
+        Assertions.assertThat(fresh.getEventStatus()).isEqualTo(EventStatus.PROCESSING);
+        Assertions.assertThat(fresh.getRetryCount()).isEqualTo(beforeRetryCount + 1);
+    }
+
+    @DisplayName("makeRetry 호출할 때 outboxId가 null인 경우 IllegalArgumentException가 발생하고 상태를 변경하지 못한다.")
+    @Test
+    void makeRetryTestWithException() {
+        // when // then
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.makeRetry(null, EventStatus.PROCESSING)
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("outboxId가 null입니다.");
+    }
+
+    @DisplayName("retryCount가 maxRetryCount 이상인 상태에서 makeFail을 호출하면 EventStatus 값이 FAIL이 된다.")
+    @Test
+    void makeFailTest() {
+        // given
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            EventType.ORDER_CREATED,
+            UUID.fromString("3f9b8c1d-4e7e-4c1a-a8fd-2a6a7f9c3b44"),
+            "Test Payload Data"
+        );
+
+        Outbox saveOutbox = outboxRepository.save(outbox);
+
+        outboxRepository.claim(saveOutbox.getId(), EventStatus.PROCESSING);
+
+        outboxRepository.makeRetry(saveOutbox.getId(), EventStatus.PROCESSING);
+
+        int maxRetryCount = 1;
+
+        // when
+        int result = outboxRepository.makeFail(saveOutbox.getId(), EventStatus.FAILED, maxRetryCount);
+
+        Outbox fresh = outboxRepository.findById(saveOutbox.getId());
+
+        // then
+        Assertions.assertThat(result).isEqualTo(1);
+        Assertions.assertThat(fresh.getEventStatus()).isEqualTo(EventStatus.FAILED);
+        Assertions.assertThat(fresh.getRetryCount()).isGreaterThanOrEqualTo(maxRetryCount);
+    }
+
+    @DisplayName("makeFail 호출할 때 outboxId가 null인 경우 IllegalArgumentException가 발생하고 상태를 변경하지 못한다.")
+    @Test
+    void makeFailTestWithNullIdException() {
+        // when // then
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.makeFail(null, EventStatus.FAILED, 1)
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("outboxId가 null입니다.");
+    }
+
+    @DisplayName("makeFail 호출할 때 maxRetryCount가 null이거나 1보다 작으면 IllegalArgumentException가 발생한다.")
+    @Test
+    void makeFailTestWithInvalidMaxRetryCountException() {
+        // given
+        Outbox outbox = Outbox.create(
+            AggregateType.ORDER,
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            EventType.ORDER_CREATED,
+            UUID.fromString("3f9b8c1d-4e7e-4c1a-a8fd-2a6a7f9c3b44"),
+            "Test Payload Data"
+        );
+        Outbox saveOutbox = outboxRepository.save(outbox);
+
+        // when // then
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.makeFail(saveOutbox.getId(), EventStatus.FAILED, null)
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("maxRetryCount 값은 필수이며 양수여야 합니다.");
+
+        // when // then
+        Assertions.assertThatThrownBy(
+                () -> outboxRepository.makeFail(saveOutbox.getId(), EventStatus.FAILED, 0)
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("maxRetryCount 값은 필수이며 양수여야 합니다.");
     }
 
 }


### PR DESCRIPTION
## 변경된 내용 

### 주문 완료 서비스 로직 
<img width="2982" height="2520" alt="CleanShot 2025-12-03 at 02 29 00@2x" src="https://github.com/user-attachments/assets/e5dd30c4-9fe3-49d6-95e4-10a2df1a0c42" />

- 이미 완료된 주문은 멱등 처리 (`isCompleted()` → `SUCCESS`)
- `CREATED` 상태에서만 `COMPLETED` 로 상태 전환
- 상태 업데이트 성공 시 `ORDER_COMPLETED` `Outbox` 이벤트 생성 및 저장
- 실패 시 예외 발생 → 트랜잭션 롤백 + `Kafka` 재전송

---

### Outbox 스케줄러/프로세서 추가
- Scheduler: `PENDING` 상태 `Outbox` 를 주기적으로 스캔하여 처리 위임
<img width="1872" height="2490" alt="CleanShot 2025-12-03 at 02 29 18@2x" src="https://github.com/user-attachments/assets/0823f7ee-4a54-474f-8b52-70891df28142" />

---

- Processor:
  - `claim()` 으로 선점 처리
  - 재시도 횟수 초과 시 FAILED로 전환
  - `OutboxCommandFactory` 를 통해 이벤트 타입별 `Kafka` 전송
  - 성공 시 `SENT`, 실패 시 `PENDING`(`+retryCount`)
<img width="1984" height="2532" alt="CleanShot 2025-12-03 at 02 30 13@2x" src="https://github.com/user-attachments/assets/bb905a6d-2d65-403c-8d18-3821d65795be" />

---

### OutboxCommand 구조 적용
- 이벤트 종류(`ORDER_CREATED`, `ORDER_COMPLETED`)에 따라 적절한 `Command` 객체 생성
- `Command` 내부에서 `KafkaTemplate` 사용하여 실제 `Kafka` 전송 수행
- `.get()` 사용으로 `Kafka` 전달 보장 및 예외 처리 명확화

---

### 결제 완료 이벤트 리스너 추가 
- `Kafka payment.completed` 이벤트 수신
- 메시지를 `CompletedPaymentEvent` 로 역직렬화
- `OrderService.completeOrder()` 호출로 주문 상태 완료 처리
- 처리 성공 시 `ack.acknowledge()` 로 오프셋 커밋
- 실패 시 `ack` 미호출 → `Kafka` 자동 재시도

---
## 기술적 선택 이유 

### Outbox 폴링 방식을 적용한 이유
- Outbox 패턴의 목적은 DB와 메시지 브로커/검색 시스템 간의 **`데이터 정합성을 맞추는 것`**
- **성능과 구조 측면에서는 CDC 방식이 더 적합**하지만, 
**`현재 팀의 인프라/운영 역량으로는 CDC를 안정적으로 운영할 자신이 없음`**
- CDC가 잘못 구성되면 오히려 정합성 리스크가 커질 수 있기 때문에,  지금 단계에서는 이해·관리가 가능한 범위인 Outbox + 폴링 방식으로 구현하는 것이 더 안전하다고 판단했다.

### 장기적으로 CDC 방식을 고려한다.
- 다만, 주문/상품 도메인의 실시간성, 불필요한 폴링 쿼리 제거, 책임 분리, 향후 서비스별 RDS 구조를 고려하면, 
장기적으로는 CDC 기반 Outbox 구성이 더 적합한 방향이라고 본다.
- 인프라 운영 역량이 쌓이면 CDC로 전환하는 것을 전제로 설계 방향을 잡는다.

--- 

### Outbox 폴링 동시성 제어를 DB 기반 선점 락(UPDATE CAS)으로 선택한 이유
- **이벤트 발행량이 전체 트래픽에 비해 적어 DB 부담이 크지 않다고 판단**
  - Outbox는 “주문 생성·완료 등 특정 시점에만” 생성되는 레코드.
  - 전체 API 요청 대비 발행 빈도가 낮아 DB 단에서 선점 처리(UPDATE … WHERE …) 도 충분히 처리 가능하다고 판단.

- **Redis 기반 분산락은 정합성 문제와 복잡도가 높음**
  - Redis SETNX/TTL 방식은
  - 락 만료 시간 설정 문제, 잠금 해제 시점 경쟁, 네트워크 분리 등 완전한 정합성을 보장하기 어려움.
  - Redisson 같은 고급 기능을 사용해도 구조 자체가 복잡해지고, 장애 상황 고려 폭이 커짐.

- **애매한 정합성보다, DB로 확실하게 정합성을 보장하는 것이 더 안전**
  - Outbox는 메시지 “중복 발행/누락”이 비즈니스적으로 치명적일 수 있음.
  - 이 부분은 애매한 보장보다는 확실한 정합성 확보가 더 중요하다고 판단.
  - DB의 단일 트랜잭션/ACID 기반 CAS(update 조건부 갱신)는 정합성이 명확하고 실패 케이스가 예측 가능함.

- **아직 아키텍처가 고정된 단계가 아니므로 MVP에서는 단순·명확한 방식이 유리**
  - Outbox는 향후 부하 테스트를 통해 Kafka 파티션 확장, CDC 도입, Redis/Etcd 기반 락 등 다양한 접근이 가능.
  - 현재는 구현 단순성 + 정합성 보장을 위해 DB 기반 분산락을 선택하고, 이후 성능 검증 후 최종 방식 확정할 예정.

## 발견된 문제점
- **Outbox PROCESSING 상태 타임아웃**
  - Outbox Worker가 레코드를 선점(`PENDING` → `PROCESSING`)한 후 다음과 같은 상황이 발생하면, 
  해당 레코드는 영구적으로 PROCESSING 상태에 머무르게 됨
  - 이후 `PROCESSING` 상태인 outbox를 복구하는 로직이 필요해 보임 
