### PR TITLE
Order 주문 확인 엔드포인트 구현 

### DIFF
--- a/order/build.gradle
+++ b/order/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 dependencyManagement {

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -29,6 +29,9 @@ ext {
 }
 
 dependencies {
+
+    implementation project(":common")
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Order;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrderRepository {
@@ -12,5 +13,7 @@ public interface OrderRepository {
     int markComplete(UUID orderId);
 
     Order findById(UUID orderId);
+
+    Optional<Order> findByAllocationKeyAndUserId(UUID allocationKey, Long userId);
 
 }

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -15,9 +15,11 @@ import com.smore.order.domain.status.EventType;
 import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.domain.status.ServiceResult;
 import com.smore.order.infrastructure.persistence.exception.CompleteOrderFailException;
+import com.smore.order.presentation.dto.IsOrderCreatedResponse;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -112,6 +114,17 @@ public class OrderService {
         outboxRepository.save(outbox);
 
         return ServiceResult.SUCCESS;
+    }
+
+    public IsOrderCreatedResponse isOrderCreated(UUID allocationKey, Long userId) {
+
+        Optional<Order> order = orderRepository.findByAllocationKeyAndUserId(
+            allocationKey, userId);
+        if (order.isEmpty()) {
+            return IsOrderCreatedResponse.notFoundOrder();
+        }
+
+        return IsOrderCreatedResponse.from(order.get());
     }
 
     // TODO: 나중에 클래스로 분리할 예정

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface OrderJpaRepositoryCustom {
     OrderEntity findByIdempotencyKey(UUID idempotencyKey);
 
     int markComplete(UUID orderId, OrderStatus status);
+
+    OrderEntity findByAllocationKeyAndUserId(UUID allocationKey, Long userId);
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
@@ -42,4 +42,16 @@ public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
 
         return (int) updated;
     }
+
+    @Override
+    public OrderEntity findByAllocationKeyAndUserId(UUID allocationKey, Long userId) {
+        return queryFactory
+            .select(orderEntity)
+            .from(orderEntity)
+            .where(
+                orderEntity.idempotencyKey.eq(allocationKey),
+                orderEntity.userId.eq(userId)
+            )
+            .fetchOne();
+    }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOrderFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOrderException;
 import com.smore.order.infrastructure.persistence.mapper.OrderMapper;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,4 +79,24 @@ public class OrderRepositoryImpl implements OrderRepository {
 
         return OrderMapper.toDomain(entity);
     }
+
+    @Override
+    public Optional<Order> findByAllocationKeyAndUserId(UUID allocationKey, Long userId) {
+
+        if (allocationKey == null) {
+            log.error("allocationKey is Null : methodName = {}", "findByAllocationKeyAndUserId()");
+            throw new IllegalArgumentException("allocationKey가 null 입니다.");
+        }
+
+        if (userId == null) {
+            log.error("userId is Null : methodName = {}", "findByAllocationKeyAndUserId()");
+            throw new IllegalArgumentException("userId가 null 입니다.");
+        }
+
+        OrderEntity entity = orderJpaRepository
+            .findByAllocationKeyAndUserId(allocationKey, userId);
+
+        return Optional.ofNullable(entity).map(OrderMapper::toDomain);
+    }
+
 }

--- a/order/src/main/java/com/smore/order/presentation/api/OrderController.java
+++ b/order/src/main/java/com/smore/order/presentation/api/OrderController.java
@@ -1,0 +1,19 @@
+package com.smore.order.presentation.api;
+
+import com.smore.common.response.CommonResponse;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+public interface OrderController {
+
+    ResponseEntity<CommonResponse<?>> isOrderCreated(
+        @NotNull(message = "userId는 필수값입니다.") @RequestHeader("X-User-Id") Long requesterId,
+        @NotBlank @RequestHeader("X-User-Role") String role,
+        @NotNull(message = "allocationToken은 필수값입니다.") @PathVariable UUID allocationToken
+    );
+
+}

--- a/order/src/main/java/com/smore/order/presentation/api/OrderControllerV1.java
+++ b/order/src/main/java/com/smore/order/presentation/api/OrderControllerV1.java
@@ -1,0 +1,44 @@
+package com.smore.order.presentation.api;
+
+import static com.smore.order.presentation.auth.OrderRole.*;
+
+import com.smore.common.error.ErrorCode;
+import com.smore.common.response.ApiResponse;
+import com.smore.common.response.CommonResponse;
+import com.smore.member.domain.enums.Role;
+import com.smore.order.application.service.OrderService;
+import com.smore.order.presentation.auth.OrderRole;
+import com.smore.order.presentation.dto.IsOrderCreatedResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderControllerV1 implements OrderController {
+
+    private final OrderService orderService;
+
+    @GetMapping("/api/v1/orders/by-token/{allocationToken}")
+    public ResponseEntity<CommonResponse<?>> isOrderCreated(
+        @RequestHeader("X-User-Id") Long requesterId,
+        @RequestHeader("X-User-Role") String role,
+        @PathVariable UUID allocationToken
+    ) {
+        OrderRole orderRole = from(role);
+
+        if (orderRole.isNotAny(CONSUMER, SELLER, ADMIN)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("5403", "접근 권한이 없습니다."));
+        }
+
+        IsOrderCreatedResponse response = orderService.isOrderCreated(allocationToken, requesterId);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/order/src/main/java/com/smore/order/presentation/api/OrderControllerV1.java
+++ b/order/src/main/java/com/smore/order/presentation/api/OrderControllerV1.java
@@ -2,10 +2,8 @@ package com.smore.order.presentation.api;
 
 import static com.smore.order.presentation.auth.OrderRole.*;
 
-import com.smore.common.error.ErrorCode;
 import com.smore.common.response.ApiResponse;
 import com.smore.common.response.CommonResponse;
-import com.smore.member.domain.enums.Role;
 import com.smore.order.application.service.OrderService;
 import com.smore.order.presentation.auth.OrderRole;
 import com.smore.order.presentation.dto.IsOrderCreatedResponse;

--- a/order/src/main/java/com/smore/order/presentation/auth/OrderRole.java
+++ b/order/src/main/java/com/smore/order/presentation/auth/OrderRole.java
@@ -1,0 +1,38 @@
+package com.smore.order.presentation.auth;
+
+public enum OrderRole {
+    NONE("비회원"),
+    ADMIN("관리자"),
+    SELLER("판매자"),
+    CONSUMER("소비자")
+    ;
+
+    private final String description;
+
+    OrderRole(String description) {
+        this.description = description;
+    }
+
+    public String desc() { return description; }
+
+    public boolean isNot(OrderRole role) {
+        return this != role;
+    }
+
+    public boolean isNotAny(OrderRole... roles) {
+        for (OrderRole role : roles) {
+            if (this == role) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static OrderRole from(String value) {
+        try {
+            return OrderRole.valueOf(value);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return OrderRole.NONE;
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/presentation/dto/IsOrderCreatedResponse.java
+++ b/order/src/main/java/com/smore/order/presentation/dto/IsOrderCreatedResponse.java
@@ -1,0 +1,40 @@
+package com.smore.order.presentation.dto;
+
+import com.smore.order.domain.model.Order;
+import com.smore.order.domain.status.OrderStatus;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class IsOrderCreatedResponse {
+
+    private final Boolean orderAvailable;
+    private final UUID orderId;
+    private final Integer totalAmount;
+    private final OrderStatus orderStatus;
+    private final UUID productId;
+    private final Integer quantity;
+
+    public static IsOrderCreatedResponse from(Order order) {
+        return IsOrderCreatedResponse.builder()
+            .orderAvailable(true)
+            .orderId(order.getId())
+            .totalAmount(order.getTotalAmount())
+            .orderStatus(order.getOrderStatus())
+            .productId(order.getProduct().productId())
+            .quantity(order.getQuantity())
+            .build();
+    }
+
+    public static IsOrderCreatedResponse notFoundOrder() {
+        return IsOrderCreatedResponse.builder()
+            .orderAvailable(false)
+            .build();
+    }
+
+}


### PR DESCRIPTION
### 추가된 내용  
- `Bid`에서 선착순 사용자에게 제공되는 `allocationKey`를 이용해 주문을 확인하는 작업이 필요 
- 주문이 생성되었는지 확인하는 `GET` `/api/v1/orders/by-token/{allocationToken}` 엔드포인트 구현 

### Service `isOrderCreated()` 메서드
- Repository로부터 allocationKey에 해당하는 주문을 가져오고 존재 유무에 따라 다른 응답을 반환 
  - 주문이 존재하지 않으면 `IsOrderCreatedResponse.notFoundOrder()`에 의해 만들어지는 DTO를 반환
  - 주문이 존재하면 주문 정보를 바탕으로 만들어진 DTO를 반환 

### Repository `findByAllocationKeyAndUserId()` 메서드
- `QueryDSL`을 이용하여 `allocationKey`와 `userId`가 일치하는 주문을 조회하는 쿼리 수행
- `Optional` 타입을 반환하여 `NPE`를 방지하고자 함 

### Controller `GET` `/api/v1/orders/by-token/{allocationToken}` 엔드포인트 구현
- @Notnull, @NotBlank Validation 적용 
- 헤더로 부터 받은 String 타입 Role을 안전하게 다루기 위해 OrderRole을 정의하여 사용 