### PR TITLE
feat: 상품 단건 조회 구현

### DIFF
--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -50,7 +50,7 @@ public class ProductService {
                 .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
 
         return new ProductResponse(product);
-
+    }
     public Page<ProductResponse> findAll(Pageable pageable) {
         return productRepository.findAll(pageable)
                 .map(ProductResponse::new);

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -7,6 +7,7 @@ import com.smore.product.domain.entity.SaleType;
 import com.smore.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -15,6 +16,7 @@ import java.util.UUID;
 public class ProductService {
     private final ProductRepository productRepository;
 
+    @Transactional
     public ProductResponse createProduct(CreateProductRequest req) {
 
         if (req.getSaleType() == SaleType.LIMITED_TO_AUCTION
@@ -22,16 +24,16 @@ public class ProductService {
             throw new IllegalArgumentException("LIMITED_TO_AUCTION requires thresholdForAuction");
         }
 
-        Product product = Product.builder()
-                .sellerId(req.getSellerId())
-                .categoryId(req.getCategoryId())
-                .name(req.getName())
-                .description(req.getDescription())
-                .price(req.getPrice())
-                .stock(req.getStock())
-                .saleType(req.getSaleType())
-                .thresholdForAuction(req.getThresholdForAuction())
-                .build();
+        Product product = Product.create(
+                req.getSellerId(),
+                req.getCategoryId(),
+                req.getName(),
+                req.getDescription(),
+                req.getPrice(),
+                req.getStock(),
+                req.getSaleType(),
+                req.getThresholdForAuction()
+        );
 
         productRepository.save(product);
 
@@ -39,9 +41,9 @@ public class ProductService {
     }
 
     public ProductResponse getProduct(UUID productId) {
-        Product p = productRepository.findById(productId)
+        Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
 
-        return new ProductResponse(p);
+        return new ProductResponse(product);
     }
 }

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -3,6 +3,7 @@ package com.smore.product.domain.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -45,15 +46,56 @@ public class Product {
     private LocalDateTime deletedAt;
     private Long deletedBy;
 
-    @PrePersist
-    public void onCreate() {
-        this.status = ProductStatus.ON_SALE;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+    public static Product create(
+            Long sellerId,
+            UUID categoryId,
+            String name,
+            String description,
+            int price,
+            int stock,
+            SaleType saleType,
+            Integer thresholdForAuction
+    ) {
+        LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
+
+        return Product.builder()
+                .sellerId(sellerId)
+                .categoryId(categoryId)
+                .name(name)
+                .description(description)
+                .price(price)
+                .stock(stock)
+                .saleType(saleType)
+                .thresholdForAuction(thresholdForAuction)
+                .status(ProductStatus.ON_SALE)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
     }
 
-    @PreUpdate
-    public void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+    public void update(
+            String name,
+            String description,
+            Integer price,
+            Integer stock,
+            UUID categoryId,
+            SaleType saleType,
+            Integer thresholdForAuction
+    ) {
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (price != null) this.price = price;
+        if (stock != null) this.stock = stock;
+        if (categoryId != null) this.categoryId = categoryId;
+        if (saleType != null) this.saleType = saleType;
+        if (thresholdForAuction != null) this.thresholdForAuction = thresholdForAuction;
+
+        this.updatedAt = LocalDateTime.now(Clock.systemUTC());
+    }
+
+    public void softDelete(Long requesterId) {
+        this.status = ProductStatus.INACTIVE;
+        this.deletedAt = LocalDateTime.now(Clock.systemUTC());
+        this.deletedBy = requesterId;
     }
 }


### PR DESCRIPTION
[ 개요 ]
상품 상세 정보를 조회하기 위한 상품 단건 조회 API (GET /api/v1/products/{productId}) 를 구현했습니다.
요청 파라미터로 전달된 productId 기반으로 상품을 조회하고, ProductResponse DTO로 반환합니다.

[ 주요 구현 내용 ]
[6321795](https://github.com/FocusCrew-4/Smore/pull/37/commits/63217952f7a8ba7eec8dfc00f8bc4b43dd0c0830)
[3af5ed2](https://github.com/FocusCrew-4/Smore/pull/37/commits/3af5ed2d45d2e060c0aa3c87db0883a26b5e6db9)

피드백 반영
[686bbd9](https://github.com/FocusCrew-4/Smore/pull/37/commits/686bbd9a927df356d45ed9e5e2253175c06a0fc2)

1) ProductService.getProduct(productId) 추가

productId로 상품 조회
존재하지 않을 경우 IllegalArgumentException("상품을 찾을 수 없습니다.") 발생
조회된 엔티티를 ProductResponse로 변환 후 반환

2) ProductController 단건조회 API 추가
GET /api/v1/products/{productId}
서비스 호출 후 CommonResponse 형태로 응답

3) ProductResponse DTO 활용
엔티티 정보를 클라이언트에 전달할 수 있도록 DTO 변환 적용

[ 테스트 ]
Postman에서 GET /api/v1/products/{productId} 호출 시 정상 반환 확인