### PR TITLE
feat: 상품 정보 수정 구현

### DIFF
--- a/member/src/main/java/com/smore/member/domain/enums/Role.java
+++ b/member/src/main/java/com/smore/member/domain/enums/Role.java
@@ -17,4 +17,15 @@ public enum Role {
     public String desc() {
         return desc;
     }
+
+    public boolean isNONE() {
+        return this == NONE;
+    }
+
+    public Role normalizeToUser() {
+        if (this == CONSUMER ||  this == SELLER) {
+            return USER;
+        }
+        return this;
+    }
 }

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.smore.product.application.service;
 
 import com.smore.product.presentation.dto.request.CreateProductRequest;
+import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.response.ProductResponse;
 import com.smore.product.domain.entity.Product;
 import com.smore.product.domain.entity.SaleType;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -50,5 +52,21 @@ public class ProductService {
     public Page<ProductResponse> findAll(Pageable pageable) {
         return productRepository.findAll(pageable)
                 .map(ProductResponse::new);
+    }
+
+    @Transactional
+    public ProductResponse updateProduct(UUID productId, UpdateProductRequest req) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다."));
+
+        if (req.getName() != null) product.setName(req.getName());
+        if (req.getDescription() != null) product.setDescription(req.getDescription());
+        if (req.getPrice() != null) product.setPrice(req.getPrice());
+        if (req.getStock() != null) product.setStock(req.getStock());
+        if (req.getCategoryId() != null) product.setCategoryId(req.getCategoryId());
+        if (req.getSaleType() != null) product.setSaleType(req.getSaleType());
+        if (req.getThresholdForAuction() != null) product.setThresholdForAuction(req.getThresholdForAuction());
+
+        return new ProductResponse(product);
     }
 }

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -57,15 +57,15 @@ public class ProductService {
     @Transactional
     public ProductResponse updateProduct(UUID productId, UpdateProductRequest req) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("상품 없음"));
 
-        if (req.getName() != null) product.setName(req.getName());
-        if (req.getDescription() != null) product.setDescription(req.getDescription());
-        if (req.getPrice() != null) product.setPrice(req.getPrice());
-        if (req.getStock() != null) product.setStock(req.getStock());
-        if (req.getCategoryId() != null) product.setCategoryId(req.getCategoryId());
-        if (req.getSaleType() != null) product.setSaleType(req.getSaleType());
-        if (req.getThresholdForAuction() != null) product.setThresholdForAuction(req.getThresholdForAuction());
+        if (req.getName() != null) product.changeName(req.getName());
+        if (req.getDescription() != null) product.changeDescription(req.getDescription());
+        if (req.getPrice() != null) product.changePrice(req.getPrice());
+        if (req.getStock() != null) product.changeStock(req.getStock());
+        if (req.getCategoryId() != null) product.changeCategory(req.getCategoryId());
+        if (req.getSaleType() != null) product.changeSaleType(req.getSaleType());
+        if (req.getThresholdForAuction() != null) product.changeThreshold(req.getThresholdForAuction());
 
         return new ProductResponse(product);
     }

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.smore.product.application.service;
 
+import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.response.ProductResponse;
@@ -60,6 +61,22 @@ public class ProductService {
     public ProductResponse updateProduct(UUID productId, UpdateProductRequest req) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new RuntimeException("상품 없음"));
+
+        if (product.getStatus() == ProductStatus.ON_SALE) {
+
+            if (req.getPrice() != null && !req.getPrice().equals(product.getPrice())) {
+                throw new IllegalStateException("판매 중인 상품은 가격을 변경할 수 없습니다.");
+            }
+
+            if (req.getSaleType() != null && req.getSaleType() != product.getSaleType()) {
+                throw new IllegalStateException("판매 중인 상품의 판매 유형은 변경할 수 없습니다.");
+            }
+
+            if (req.getThresholdForAuction() != null &&
+                    !req.getThresholdForAuction().equals(product.getThresholdForAuction())) {
+                throw new IllegalStateException("판매 중인 상품의 경매 전환 기준은 수정할 수 없습니다.");
+            }
+        }
 
         if (req.getName() != null) product.changeName(req.getName());
         if (req.getDescription() != null) product.changeDescription(req.getDescription());

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -56,4 +56,6 @@ public class Product {
     public void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+
 }

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -57,5 +57,31 @@ public class Product {
         this.updatedAt = LocalDateTime.now();
     }
 
+    public void changeName(String name) {
+        this.name = name;
+    }
 
+    public void changeDescription(String description) {
+        this.description = description;
+    }
+
+    public void changePrice(Integer price) {
+        this.price = price;
+    }
+
+    public void changeStock(Integer stock) {
+        this.stock = stock;
+    }
+
+    public void changeCategory(UUID categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public void changeSaleType(SaleType saleType) {
+        this.saleType = saleType;
+    }
+
+    public void changeThreshold(Integer threshold) {
+        this.thresholdForAuction = threshold;
+    }
 }

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.smore.common.response.ApiResponse;
 import com.smore.common.response.CommonResponse;
 import com.smore.product.application.service.ProductService;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
+import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.response.ProductResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,6 +47,15 @@ public class ProductController {
             Pageable pageable
     ) {
         Page<ProductResponse> response = productService.findAll(pageable);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<CommonResponse<ProductResponse>> update(
+            @PathVariable UUID productId,
+            @RequestBody UpdateProductRequest request
+    ) {
+        ProductResponse response = productService.updateProduct(productId, request);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/product/src/main/java/com/smore/product/presentation/dto/request/UpdateProductRequest.java
+++ b/product/src/main/java/com/smore/product/presentation/dto/request/UpdateProductRequest.java
@@ -1,0 +1,17 @@
+package com.smore.product.presentation.dto.request;
+
+import com.smore.product.domain.entity.SaleType;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class UpdateProductRequest {
+    private String name;
+    private String description;
+    private Integer price;
+    private Integer stock;
+    private UUID categoryId;
+    private SaleType saleType;
+    private Integer thresholdForAuction;
+}


### PR DESCRIPTION
[ 개요 ]
상품 정보를 부분 수정할 수 있는 상품 수정 API (PATCH /api/v1/products/{productId}) 를 구현했다.
요청으로 전달된 필드만 선택적으로 변경되도록 구성했고, 엔티티는 change 메서드로만 상태를 바꾸도록 설계했다.

[ 주요 구현 내용 ]
[9501220](https://github.com/FocusCrew-4/Smore/pull/39/commits/95012204f3ceaa5c54179ee0cd0135af9611b912)
[5662162](https://github.com/FocusCrew-4/Smore/pull/39/commits/56621621c1aa6f2261598280af0cb1019e683595)
[5edf7a8](https://github.com/FocusCrew-4/Smore/pull/39/commits/5edf7a8ce6d263f66cf67070cb7751915692be64)
[4728e68](https://github.com/FocusCrew-4/Smore/pull/39/commits/4728e684c591b9399c5b97d230a6df22cc0fdd36)

피드백 반영
[dfb9830](https://github.com/FocusCrew-4/Smore/pull/39/commits/dfb98308865b56a4474e632438c4d76badf9715a)

1) UpdateProductRequest DTO 추가
수정 가능한 필드만 포함
null 값은 무시하는 partial update 방식

2) Product 엔티티에 change 계열 메서드 추가
Setter 대신 명확한 목적을 가진 변경 메서드를 제공해 엔티티 무결성 유지.

3) ProductService.updateProduct() 구현
productId로 상품 조회
요청 DTO의 값이 존재할 때만 해당 필드 변경
변경된 상품을 ProductResponse로 반환

4) ProductController PATCH API 추가

[ 테스트 ]
Postman에서 필요한 필드만 전달해 부분 수정 정상 확인
미전달 필드는 그대로 유지됨
