### PR TITLE
feat: seller/publishEvent

### DIFF
--- a/member/src/main/java/com/smore/MemberApplication.java
+++ b/member/src/main/java/com/smore/MemberApplication.java
@@ -4,8 +4,10 @@ import java.time.Clock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MemberApplication {
 
     public static void main(String[] args) {

--- a/member/src/main/java/com/smore/seller/application/impl/SellerApplyImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/SellerApplyImpl.java
@@ -23,6 +23,10 @@ public class SellerApplyImpl implements SellerApply {
     @Override
     public SellerResult sellerApply(ApplyCommand applyCommand) {
 
+        if (repository.findByMemberId(applyCommand.requesterId()) != null) {
+            throw new IllegalStateException("이미 존재하는 요청자 입니다");
+        }
+
         Seller newSeller = Seller.apply(
             applyCommand.requesterId(),
             applyCommand.accountNum(),

--- a/member/src/main/java/com/smore/seller/application/impl/SellerApproveImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/SellerApproveImpl.java
@@ -45,7 +45,8 @@ public class SellerApproveImpl implements SellerApprove {
         outboxRepository.saveOutBox(
             sellerTopic.getSellerRegisterTopic("v1"),
             seller.getMemberId(),
-            eventSerializer.serializeEvent(event)
+            eventSerializer.serializeEvent(event),
+            clock
         );
         repository.save(seller);
     }

--- a/member/src/main/java/com/smore/seller/application/impl/SellerApproveImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/SellerApproveImpl.java
@@ -5,17 +5,19 @@ import com.smore.seller.domain.events.SellerRegisterV1Event;
 import com.smore.seller.domain.model.Seller;
 import com.smore.seller.domain.repository.SellerRepository;
 import com.smore.seller.infrastructure.kafka.SellerEventSerializer;
-import com.smore.seller.infrastructure.persistence.jpa.entity.SellerOutbox;
-import com.smore.seller.infrastructure.persistence.jpa.repository.SellerOutboxRepository;
+import com.smore.seller.infrastructure.outbox.SellerOutbox;
+import com.smore.seller.infrastructure.outbox.SellerOutboxRepository;
 import java.time.Clock;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class SellerApproveImpl implements SellerApprove {
 
     private final SellerRepository repository;

--- a/member/src/main/java/com/smore/seller/application/port/EventSerializerPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/EventSerializerPort.java
@@ -1,0 +1,7 @@
+package com.smore.seller.application.port;
+
+public interface EventSerializerPort {
+
+    String serializeEvent(Object event);
+
+}

--- a/member/src/main/java/com/smore/seller/application/port/SellerTopicPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/SellerTopicPort.java
@@ -1,0 +1,5 @@
+package com.smore.seller.application.port;
+
+public interface SellerTopicPort {
+    String getSellerRegisterTopic(String version);
+}

--- a/member/src/main/java/com/smore/seller/application/port/out/OutboxRepositoryPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/out/OutboxRepositoryPort.java
@@ -1,5 +1,7 @@
 package com.smore.seller.application.port.out;
 
+import java.time.Clock;
+
 public interface OutboxRepositoryPort {
-    void saveOutBox(String topic, Long key, String payload);
+    void saveOutBox(String topic, Long key, String payload, Clock clock);
 }

--- a/member/src/main/java/com/smore/seller/application/port/out/OutboxRepositoryPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/out/OutboxRepositoryPort.java
@@ -1,0 +1,5 @@
+package com.smore.seller.application.port.out;
+
+public interface OutboxRepositoryPort {
+    void saveOutBox(String topic, Long key, String payload);
+}

--- a/member/src/main/java/com/smore/seller/domain/events/SellerRegisterV1Event.java
+++ b/member/src/main/java/com/smore/seller/domain/events/SellerRegisterV1Event.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class SellerRegisterV1Event {
     Long memberId;
     UUID idempotencyKey;
-    LocalDateTime dateTime;
+    LocalDateTime createdAt;
 
     public static SellerRegisterV1Event create(
         Long memberId,

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/EventSerializerPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/EventSerializerPortImpl.java
@@ -1,0 +1,19 @@
+package com.smore.seller.infrastructure.adaptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.seller.application.port.EventSerializerPort;
+import com.smore.seller.infrastructure.kafka.SellerEventSerializer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventSerializerPortImpl implements EventSerializerPort {
+
+    private final SellerEventSerializer serializer;
+
+    @Override
+    public String serializeEvent(Object event) {
+        return serializer.toJsonString(event);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/SellerTopicPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/SellerTopicPortImpl.java
@@ -1,0 +1,18 @@
+package com.smore.seller.infrastructure.adaptor;
+
+import com.smore.seller.application.port.SellerTopicPort;
+import com.smore.seller.infrastructure.kafka.SellerTopicProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SellerTopicPortImpl implements SellerTopicPort {
+
+    private final SellerTopicProperties sellerTopicProperties;
+
+    @Override
+    public String getSellerRegisterTopic(String version) {
+        return sellerTopicProperties.getSellerRegister().get(version);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/out/OutboxRepositoryPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/out/OutboxRepositoryPortImpl.java
@@ -12,10 +12,9 @@ import org.springframework.stereotype.Repository;
 public class OutboxRepositoryPortImpl implements OutboxRepositoryPort {
 
     private final SellerOutboxRepository repository;
-    private final Clock clock;
-
+    // TODO: repo 에서 new 를 통해서 새로운 객체를 받아오는 것은 SRP 에 어긋난다 추후 DTO 와 mapper 를 통해 분리필요
     @Override
-    public void saveOutBox(String topic, Long key, String payload) {
+    public void saveOutBox(String topic, Long key, String payload, Clock clock) {
         SellerOutbox sellerOutbox = new SellerOutbox(
             topic,
             key,

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/out/OutboxRepositoryPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/out/OutboxRepositoryPortImpl.java
@@ -1,0 +1,27 @@
+package com.smore.seller.infrastructure.adaptor.out;
+
+import com.smore.seller.application.port.out.OutboxRepositoryPort;
+import com.smore.seller.infrastructure.outbox.SellerOutbox;
+import com.smore.seller.infrastructure.outbox.SellerOutboxRepository;
+import java.time.Clock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryPortImpl implements OutboxRepositoryPort {
+
+    private final SellerOutboxRepository repository;
+    private final Clock clock;
+
+    @Override
+    public void saveOutBox(String topic, Long key, String payload) {
+        SellerOutbox sellerOutbox = new SellerOutbox(
+            topic,
+            key,
+            payload,
+            clock
+        );
+        repository.save(sellerOutbox);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -36,7 +36,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerRegisterV1Topic() {
         return TopicBuilder.name("seller.register.v1")
-            .partitions(1)
+            .partitions(2)
             .replicas(3)
             .build();
     }
@@ -44,7 +44,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerDisabledV1Topic() {
         return TopicBuilder.name("seller.disabled.v1")
-            .partitions(1)
+            .partitions(2)
             .replicas(3)
             .build();
     }

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -36,7 +36,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerRegisterV1Topic() {
         return TopicBuilder.name("seller.register.v1")
-            .partitions(2)
+            .partitions(1)
             .replicas(3)
             .build();
     }
@@ -44,7 +44,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerDisabledV1Topic() {
         return TopicBuilder.name("seller.disabled.v1")
-            .partitions(2)
+            .partitions(1)
             .replicas(3)
             .build();
     }

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -1,6 +1,7 @@
 package com.smore.seller.infrastructure.kafka;
 
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,10 +11,12 @@ import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaAdmin;
 
 @Configuration
+@RequiredArgsConstructor
 public class SellerKafkaTopicConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+    private final SellerTopicProperties topicProperties;
 
     @Bean
     /*
@@ -35,7 +38,7 @@ public class SellerKafkaTopicConfig {
     // 판매자 상태변경과 등록은 자주 일어나는 이벤트는 아니기 때문에 파티션 2
     @Bean
     public NewTopic SellerRegisterV1Topic() {
-        return TopicBuilder.name("seller.register.v1")
+        return TopicBuilder.name(topicProperties.getSellerRegister().get("v1"))
             .partitions(2)
             .replicas(3)
             .build();

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerTopicProperties.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerTopicProperties.java
@@ -1,0 +1,17 @@
+package com.smore.seller.infrastructure.kafka;
+
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "topic.produce")
+@Component
+@Getter
+@Setter
+public class SellerTopicProperties {
+
+    private Map<String, String> sellerRegister;
+
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutbox.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutbox.java
@@ -1,4 +1,4 @@
-package com.smore.seller.infrastructure.persistence.jpa.entity;
+package com.smore.seller.infrastructure.outbox;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_seller_outbox")
@@ -28,11 +30,13 @@ public class SellerOutbox {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 발행될 카프카 토픽명
     private String eventType;
 
+    // partition key 로 사용 (kafka key)
     private Long memberId;
 
-    @Lob
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "json")
     private String payload;
 

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxDispatcher.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxDispatcher.java
@@ -1,0 +1,57 @@
+package com.smore.seller.infrastructure.outbox;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SellerOutboxDispatcher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final SellerOutboxRepository repository;
+    private final Clock clock;
+
+    private static final int MAX_RETRY = 3;
+
+    @Transactional
+    public void dispatch(SellerOutbox event) {
+        try {
+            var future = kafkaTemplate.send(
+                event.getEventType(),
+                event.getMemberId().toString(),
+                event.getPayload()
+            );
+
+            future.get();
+
+            repository.markSent(
+                event.getId(),
+                LocalDateTime.now(clock)
+            );
+        } catch (Exception e) {
+            handleFailure(event, e);
+        }
+    }
+    private void handleFailure(SellerOutbox event, Exception e) {
+
+        int retry = event.getRetryCount() + 1;
+        if (retry >= MAX_RETRY) {
+            repository.markFailed(
+                event.getId(),
+                e.getMessage(),
+                LocalDateTime.now(clock)
+            );
+        } else {
+            repository.updateRetry(
+                event.getId(),
+                retry,
+                e.getMessage(),
+                LocalDateTime.now(clock)
+            );
+        }
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxFetcher.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxFetcher.java
@@ -1,0 +1,29 @@
+package com.smore.seller.infrastructure.outbox;
+
+import com.smore.seller.infrastructure.outbox.SellerOutbox.MessageStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// 조회전용 계층
+@Component
+@RequiredArgsConstructor
+public class SellerOutboxFetcher {
+
+    private final SellerOutboxRepository sellerOutboxRepository;
+
+    public List<SellerOutbox> fetchPending() {
+
+        //region 동적으로 배치사이즈를 변경하고 싶으면 인자로 int batchSize 를 받아와서 사용
+//        Pageable pageable = PageRequest.of(0, batchSize);
+//
+//        sellerOutboxRepository.findByStatusOrderByIdAsc(
+//            MessageStatus.PENDING, pageable
+//        );
+        //endregion
+
+        return sellerOutboxRepository.findTop100ByStatusOrderByIdAsc(
+            MessageStatus.PENDING
+        );
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxProcessor.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxProcessor.java
@@ -1,0 +1,32 @@
+package com.smore.seller.infrastructure.outbox;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SellerOutboxProcessor {
+
+    private final SellerOutboxFetcher fetcher;
+    private final SellerOutboxDispatcher dispatcher;
+
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 2000)
+    public void process() {
+        List<SellerOutbox> events = fetcher.fetchPending();
+        for (SellerOutbox event : events) {
+            try {
+                dispatcher.dispatch(event);
+            } catch (Exception e) {
+                // 절대 throw 하지 않음
+                log.error("[Outbox] Unexpected error while processing id={}", event.getId(), e);
+            }
+        }
+    }
+
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxRepository.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxRepository.java
@@ -1,0 +1,35 @@
+package com.smore.seller.infrastructure.outbox;
+
+import com.smore.seller.infrastructure.outbox.SellerOutbox.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SellerOutboxRepository extends CrudRepository<SellerOutbox, Long> {
+
+    List<SellerOutbox> findTop100ByStatusOrderByIdAsc(
+        MessageStatus messageStatus
+    );
+
+    // batchSize 를 동적으로 변환하고 싶다면 사용
+    List<SellerOutbox> findByStatusOrderByIdAsc(
+        SellerOutbox.MessageStatus status,
+        Pageable pageable
+    );
+
+    @Modifying
+    @Query("UPDATE SellerOutbox o SET o.status = 'SENT', o.processedAt = :processedAt, o.errorMessage = null WHERE o.id = :id")
+    void markSent(Long id, LocalDateTime processedAt);
+
+    @Modifying
+    @Query("UPDATE SellerOutbox o SET o.retryCount = :retry, o.errorMessage = :error, o.processedAt = :processedAt WHERE o.id = :id")
+    void updateRetry(Long id, int retry, String error, LocalDateTime processedAt);
+
+    @Modifying
+    @Query("UPDATE SellerOutbox o SET o.status = 'FAILED', o.errorMessage = :error, o.processedAt = :processedAt WHERE o.id = :id")
+    void markFailed(Long id, String error, LocalDateTime processedAt);
+
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxRepository.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxRepository.java
@@ -20,6 +20,7 @@ public interface SellerOutboxRepository extends CrudRepository<SellerOutbox, Lon
         Pageable pageable
     );
 
+    // TODO: 추후 쿼리dsl 로 이관 필요
     @Modifying
     @Query("UPDATE SellerOutbox o SET o.status = 'SENT', o.processedAt = :processedAt, o.errorMessage = null WHERE o.id = :id")
     void markSent(Long id, LocalDateTime processedAt);

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/SellerRepositoryImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/SellerRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.smore.seller.infrastructure.persistence.jpa.entity.SellerJpa;
 import com.smore.seller.infrastructure.persistence.jpa.mapper.SellerJpaMapper;
 import com.smore.seller.infrastructure.persistence.jpa.repository.SellerJpaRepository;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -34,9 +35,8 @@ public class SellerRepositoryImpl implements SellerRepository {
 
     @Override
     public Seller findById(UUID id) {
-        SellerJpa sellerJpa = repository.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Seller with id " + id + " not found"));
-        return mapper.toDomain(sellerJpa);
+        Optional<SellerJpa> sellerJpa = repository.findById(id);
+        return sellerJpa.map(mapper::toDomain)
+            .orElse(null);
     }
-
 }

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/entity/SellerJpa.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/entity/SellerJpa.java
@@ -2,6 +2,7 @@ package com.smore.seller.infrastructure.persistence.jpa.entity;
 
 import com.smore.seller.domain.enums.SellerStatus;
 import com.smore.seller.infrastructure.persistence.jpa.vo.MoneyEmbeddable;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,6 +28,7 @@ public class SellerJpa {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
+    @Column(unique = true)
     private Long memberId;
     private String accountNum;
     @Enumerated(EnumType.STRING)

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/entity/SellerJpa.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/entity/SellerJpa.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -23,8 +24,16 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "p_seller")
+@Table(
+    name = "p_seller",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_p_seller_member_id",
+            columnNames = {"member_id"}
+        )
+    })
 public class SellerJpa {
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/repository/SellerOutboxRepository.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/repository/SellerOutboxRepository.java
@@ -1,8 +1,0 @@
-package com.smore.seller.infrastructure.persistence.jpa.repository;
-
-import com.smore.seller.infrastructure.persistence.jpa.entity.SellerOutbox;
-import org.springframework.data.repository.CrudRepository;
-
-public interface SellerOutboxRepository extends CrudRepository<SellerOutbox, Long> {
-
-}

--- a/member/src/main/resources/application-local.yml
+++ b/member/src/main/resources/application-local.yml
@@ -76,3 +76,9 @@ springdoc:
 eureka:
   client:
     enabled: false
+
+topic:
+  produce:
+    seller-register:
+      v1: seller.register.v1
+      v2: seller.register.v2

--- a/member/src/main/resources/data.sql
+++ b/member/src/main/resources/data.sql
@@ -20,3 +20,25 @@ VALUES
     ('00000000-0000-0000-0000-000000000004', 5, '444-44-444444', 'DELETED', NOW(), NOW(), NOW(), 1),
     ('00000000-0000-0000-0000-000000000005', 6, '555-55-555555', 'BANNED', NOW(), NOW(), NOW(), 1)
 ON CONFLICT DO NOTHING;
+--
+-- -- Seed: seller outbox pending 230 rows
+-- INSERT INTO p_seller_outbox (
+--     created_at,
+--     error_message,
+--     event_type,
+--     member_id,
+--     payload,
+--     processed_at,
+--     retry_count,
+--     status
+-- )
+-- SELECT
+--     NOW(),
+--     NULL,
+--     'seller.register.v1',
+--     200000 + g,                             -- dummy member id
+--     json_build_object('seed', g)::json,     -- dummy payload
+--     NULL,
+--     0,
+--     'PENDING'
+-- FROM generate_series(1, 230) g;


### PR DESCRIPTION
## kafka 이벤트 발행
f3506668b96390eff27e93648ce69e0d73627f2d
- 싱글 스레드 스케줄러를 통한 이벤트 발행으로 구현
- kafka 파티션에 순서를 정확하게 넣어줘야 해서 싱글 스레드 사용

## application 계층에서 infra 계층의존 분리
1a4bef15d9021173e6e615ec4d382902306e4d16
- application 계층에서 infra 계층을 직접 import 하는 부분을 port 인터페이스를 통해서 분리하였습니다

## memberId 컬럼 unique 설정
455fb4673bd4ecde702a1795eb7d122427235d03
- 한 멤버당 한개의 요청만 만들 수 있게 변경하였습니다

---

## 코드 리뷰 반영
[b881086](https://github.com/FocusCrew-4/Smore/pull/41/commits/b881086b7840db9c2242b74c86b1febb8812b1bb)

- UK 조건명 명시
- 쿼리 dls 로 이관할 코드 표시
- repo 에서 Clock 을 의존하던 문제해결 및 추후 개선사항 기록