### PR TITLE
feat: member/internalJwtVerifyAPI

### DIFF
--- a/gateway/src/main/java/com/smore/gateway/filter/JwtValidationFilter.java
+++ b/gateway/src/main/java/com/smore/gateway/filter/JwtValidationFilter.java
@@ -45,9 +45,9 @@ public class JwtValidationFilter implements GlobalFilter, Ordered {
         Jwt jwt;
         // Jwt 자체를 검증
         try {
-            jwt = jwtValidation.validateJwt(bearerJwt);
+            jwt = jwtValidation.validateJwt(bearerJwt.replace("Bearer ", ""));
         } catch (JwtException e) {
-            log.error(e.getMessage());
+            log.error("fliter Jwt 검증단 오류 {}", e.getMessage());
             var response = exchange.getResponse();
             response.setStatusCode(HttpStatus.UNAUTHORIZED);
             return response.setComplete();

--- a/gateway/src/main/java/com/smore/gateway/infra/JwtValidationImpl.java
+++ b/gateway/src/main/java/com/smore/gateway/infra/JwtValidationImpl.java
@@ -25,17 +25,17 @@ public class JwtValidationImpl implements JwtValidation {
     @Override
     public Mono<Boolean> validateClaim(String token) {
 
-//        Mono<Boolean> memberResponse = webClient.build()
-//            // HTTP 메서드 종류 지정
-//            .method(HttpMethod.GET)
-//            // 요청을 보낼 uri 설정
-//            .uri("")
-//            // header 정보 설정
-//            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-//            // retrieve 는 HTTP 요청을 보내고 서버의 응답을 비동기적으로 받기 위한 준비를 한다
-//            .retrieve()
-//            .bodyToMono(Boolean.class);
+        Mono<Boolean> memberResponse = webClient.build()
+            // HTTP 메서드 종류 지정
+            .method(HttpMethod.GET)
+            // 요청을 보낼 uri 설정
+            .uri("lb://member-service/api/v1/internal/members")
+            // header 정보 설정
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            // retrieve 는 HTTP 요청을 보내고 서버의 응답을 비동기적으로 받기 위한 준비를 한다
+            .retrieve()
+            .bodyToMono(Boolean.class);
 
-        return Mono.just(true);
+        return memberResponse;
     }
 }

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
             - id: member-service
               uri: lb://member-service
               predicates:
-                - Path=/api/v*/members/**
+                - Path=/api/v*/members/**,/api/v*/internal/members/**,/api/v*/sellers/**
 
             - id: auction-service
               uri: lb://auction-service

--- a/member/src/main/java/com/smore/MemberApplication.java
+++ b/member/src/main/java/com/smore/MemberApplication.java
@@ -4,8 +4,10 @@ import java.time.Clock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MemberApplication {
 
     public static void main(String[] args) {

--- a/member/src/main/java/com/smore/member/application/port/in/MemberJwtVerify.java
+++ b/member/src/main/java/com/smore/member/application/port/in/MemberJwtVerify.java
@@ -1,0 +1,7 @@
+package com.smore.member.application.port.in;
+
+public interface MemberJwtVerify {
+
+    boolean verify(String jwt);
+
+}

--- a/member/src/main/java/com/smore/member/application/service/impl/MemberRoleChangeImpl.java
+++ b/member/src/main/java/com/smore/member/application/service/impl/MemberRoleChangeImpl.java
@@ -1,0 +1,24 @@
+package com.smore.member.application.service.impl;
+
+import com.smore.member.application.service.usecase.MemberRoleChange;
+import com.smore.member.domain.model.Member;
+import com.smore.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberRoleChangeImpl
+    implements MemberRoleChange {
+
+    private final MemberRepository repository;
+
+    @Override
+    public void toSeller(Long targetId) {
+        Member member = repository.findById(targetId);
+        member.toSeller();
+        repository.save(member);
+    }
+}

--- a/member/src/main/java/com/smore/member/application/service/usecase/MemberRoleChange.java
+++ b/member/src/main/java/com/smore/member/application/service/usecase/MemberRoleChange.java
@@ -1,0 +1,7 @@
+package com.smore.member.application.service.usecase;
+
+public interface MemberRoleChange {
+
+    void toSeller(Long targetId);
+
+}

--- a/member/src/main/java/com/smore/member/domain/model/Member.java
+++ b/member/src/main/java/com/smore/member/domain/model/Member.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class Member {
 
     private final Long id;
-    private final Role role;
+    private Role role;
     private Credential credential;
     private String nickname;
     private Integer auctionCancelCount;
@@ -51,6 +51,10 @@ public class Member {
             throw new IllegalArgumentException("nickname cannot be null or empty");
         }
         this.nickname = nickname;
+    }
+
+    public void toSeller() {
+        this.role = Role.SELLER;
     }
 
     public void changeEmail(String email) {

--- a/member/src/main/java/com/smore/member/domain/model/Member.java
+++ b/member/src/main/java/com/smore/member/domain/model/Member.java
@@ -76,4 +76,8 @@ public class Member {
     public boolean isMe(Long memberId) {
         return this.id.equals(memberId);
     }
+
+    public boolean isSameRole(Role role) {
+        return this.role == role;
+    }
 }

--- a/member/src/main/java/com/smore/member/infrastructure/adapter/in/MemberJwtVerifyImpl.java
+++ b/member/src/main/java/com/smore/member/infrastructure/adapter/in/MemberJwtVerifyImpl.java
@@ -1,0 +1,41 @@
+package com.smore.member.infrastructure.adapter.in;
+
+import com.smore.member.application.port.in.MemberJwtVerify;
+import com.smore.member.domain.enums.Role;
+import com.smore.member.domain.model.Member;
+import com.smore.member.domain.repository.MemberRepository;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemberJwtVerifyImpl implements MemberJwtVerify {
+
+    private final JwtDecoder jwtDecoder;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean verify(String token) {
+        try {
+            Jwt jwt1 = jwtDecoder.decode(token.replace("Bearer ", ""));
+            Long memberId = Long.valueOf(jwt1.getSubject());
+            Member member = memberRepository.findById(memberId);
+            if (!member.isSameRole(Role.valueOf(jwt1.getClaim("role")))) {
+                return false;
+            }
+        } catch (JwtException e) {
+            log.error("Jwt exception", e);
+            return false;
+        } catch (NoSuchElementException e) {
+            log.error("유효한 회원이 없습니다", e);
+            return false;
+        }
+        return true;
+    }
+}

--- a/member/src/main/java/com/smore/member/infrastructure/kafka/config/MemberTopicProperties.java
+++ b/member/src/main/java/com/smore/member/infrastructure/kafka/config/MemberTopicProperties.java
@@ -1,4 +1,4 @@
-package com.smore.seller.infrastructure.kafka;
+package com.smore.member.infrastructure.kafka.config;
 
 import java.util.Map;
 import lombok.Getter;
@@ -6,11 +6,11 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@ConfigurationProperties(prefix = "seller.topic")
+@ConfigurationProperties(prefix = "member.topic")
 @Component
 @Getter
 @Setter
-public class SellerTopicProperties {
+public class MemberTopicProperties {
 
     private Map<String, String> sellerRegister;
 

--- a/member/src/main/java/com/smore/member/infrastructure/kafka/listener/MemberSampleListener.java
+++ b/member/src/main/java/com/smore/member/infrastructure/kafka/listener/MemberSampleListener.java
@@ -2,6 +2,7 @@ package com.smore.member.infrastructure.kafka.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smore.member.application.service.usecase.MemberRoleChange;
+import com.smore.member.infrastructure.kafka.config.MemberTopicProperties;
 import com.smore.member.infrastructure.kafka.listener.dto.SellerRegisterV1;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +21,7 @@ public class MemberSampleListener {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
-        topics = "seller.register.v1"
+        topics = "${member.topic.seller-register.v1}"
     )
     public void consume(String event, Acknowledgment ack) {
         try {

--- a/member/src/main/java/com/smore/member/infrastructure/kafka/listener/MemberSampleListener.java
+++ b/member/src/main/java/com/smore/member/infrastructure/kafka/listener/MemberSampleListener.java
@@ -1,19 +1,45 @@
 package com.smore.member.infrastructure.kafka.listener;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.member.application.service.usecase.MemberRoleChange;
+import com.smore.member.infrastructure.kafka.listener.dto.SellerRegisterV1;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @ConditionalOnProperty(name = "spring.kafka.bootstrap-servers")
+@RequiredArgsConstructor
 public class MemberSampleListener {
 
+    private final MemberRoleChange memberRoleChange;
+    private final ObjectMapper objectMapper;
+
     @KafkaListener(
-        topics = "member-sample"
+        topics = "seller.register.v1"
     )
-    public void consume(String message) {
-        log.info("Received message on member-sample: {}", message);
+    public void consume(String event, Acknowledgment ack) {
+        try {
+            log.info("Received message on member-sample: {}", event);
+
+            // 처리 로직
+            // ...
+            SellerRegisterV1 sellerRegisterV1 = objectMapper.readValue(event, SellerRegisterV1.class);
+            log.info("SellerRegisterV1: {}", sellerRegisterV1);
+            log.info("SellerRegisterV1: {}", sellerRegisterV1.memberId());
+            log.info("SellerRegisterV1: {}", sellerRegisterV1.idempotencyKey());
+            memberRoleChange.toSeller(sellerRegisterV1.memberId());
+
+            ack.acknowledge(); // 수동 offset commit 필수
+        } catch (Exception e) {
+            log.error("Error processing message", e);
+            // ack 안 함 → 메시지 다시 받을 수 있음
+            // 또는 retry, DLQ 처리 전략 선택
+        }
+
     }
 }

--- a/member/src/main/java/com/smore/member/infrastructure/kafka/listener/dto/SellerRegisterV1.java
+++ b/member/src/main/java/com/smore/member/infrastructure/kafka/listener/dto/SellerRegisterV1.java
@@ -1,0 +1,12 @@
+package com.smore.member.infrastructure.kafka.listener.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record SellerRegisterV1(
+    Long memberId,
+    UUID idempotencyKey,
+    OffsetDateTime createdAt
+) {
+
+}

--- a/member/src/main/java/com/smore/member/presentation/internal/MemberInternalController.java
+++ b/member/src/main/java/com/smore/member/presentation/internal/MemberInternalController.java
@@ -1,0 +1,37 @@
+package com.smore.member.presentation.internal;
+
+import com.smore.common.response.ApiResponse;
+import com.smore.common.response.CommonResponse;
+import com.smore.common.response.ErrorResponse;
+import com.smore.member.application.port.in.MemberJwtVerify;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/internal/members")
+@RestController
+@RequiredArgsConstructor
+public class MemberInternalController {
+
+    private final MemberJwtVerify memberJwtVerify;
+
+    // TODO: 에러타입 맞추기 필요
+    @GetMapping()
+    public Boolean verifyJwtMember(
+        @RequestHeader("Authorization") String jwtToken
+    ) {
+        boolean isOk = memberJwtVerify.verify(jwtToken);
+
+//        if (!isOk) {
+//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+//                .body(ApiResponse.error("M401", "jwt 정보와 회원 정보가 일치하지 않습니다"));
+//        }
+//        return ResponseEntity.ok(ApiResponse.ok(isOk));
+
+        return isOk;
+    }
+}

--- a/member/src/main/java/com/smore/seller/application/impl/SellerApplyImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/SellerApplyImpl.java
@@ -23,6 +23,10 @@ public class SellerApplyImpl implements SellerApply {
     @Override
     public SellerResult sellerApply(ApplyCommand applyCommand) {
 
+        if (repository.findByMemberId(applyCommand.requesterId()) != null) {
+            throw new IllegalStateException("이미 존재하는 요청자 입니다");
+        }
+
         Seller newSeller = Seller.apply(
             applyCommand.requesterId(),
             applyCommand.accountNum(),

--- a/member/src/main/java/com/smore/seller/application/impl/SellerApproveImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/SellerApproveImpl.java
@@ -5,17 +5,19 @@ import com.smore.seller.domain.events.SellerRegisterV1Event;
 import com.smore.seller.domain.model.Seller;
 import com.smore.seller.domain.repository.SellerRepository;
 import com.smore.seller.infrastructure.kafka.SellerEventSerializer;
-import com.smore.seller.infrastructure.persistence.jpa.entity.SellerOutbox;
-import com.smore.seller.infrastructure.persistence.jpa.repository.SellerOutboxRepository;
+import com.smore.seller.infrastructure.outbox.SellerOutbox;
+import com.smore.seller.infrastructure.outbox.SellerOutboxRepository;
 import java.time.Clock;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class SellerApproveImpl implements SellerApprove {
 
     private final SellerRepository repository;

--- a/member/src/main/java/com/smore/seller/application/port/EventSerializerPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/EventSerializerPort.java
@@ -1,0 +1,7 @@
+package com.smore.seller.application.port;
+
+public interface EventSerializerPort {
+
+    String serializeEvent(Object event);
+
+}

--- a/member/src/main/java/com/smore/seller/application/port/SellerTopicPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/SellerTopicPort.java
@@ -1,0 +1,5 @@
+package com.smore.seller.application.port;
+
+public interface SellerTopicPort {
+    String getSellerRegisterTopic(String version);
+}

--- a/member/src/main/java/com/smore/seller/application/port/out/OutboxRepositoryPort.java
+++ b/member/src/main/java/com/smore/seller/application/port/out/OutboxRepositoryPort.java
@@ -1,0 +1,5 @@
+package com.smore.seller.application.port.out;
+
+public interface OutboxRepositoryPort {
+    void saveOutBox(String topic, Long key, String payload);
+}

--- a/member/src/main/java/com/smore/seller/domain/events/SellerRegisterV1Event.java
+++ b/member/src/main/java/com/smore/seller/domain/events/SellerRegisterV1Event.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class SellerRegisterV1Event {
     Long memberId;
     UUID idempotencyKey;
-    LocalDateTime dateTime;
+    LocalDateTime createdAt;
 
     public static SellerRegisterV1Event create(
         Long memberId,

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/EventSerializerPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/EventSerializerPortImpl.java
@@ -1,6 +1,5 @@
 package com.smore.seller.infrastructure.adaptor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smore.seller.application.port.EventSerializerPort;
 import com.smore.seller.infrastructure.kafka.SellerEventSerializer;
 import lombok.RequiredArgsConstructor;

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/EventSerializerPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/EventSerializerPortImpl.java
@@ -1,0 +1,19 @@
+package com.smore.seller.infrastructure.adaptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.seller.application.port.EventSerializerPort;
+import com.smore.seller.infrastructure.kafka.SellerEventSerializer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventSerializerPortImpl implements EventSerializerPort {
+
+    private final SellerEventSerializer serializer;
+
+    @Override
+    public String serializeEvent(Object event) {
+        return serializer.toJsonString(event);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/SellerTopicPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/SellerTopicPortImpl.java
@@ -1,0 +1,18 @@
+package com.smore.seller.infrastructure.adaptor;
+
+import com.smore.seller.application.port.SellerTopicPort;
+import com.smore.seller.infrastructure.kafka.SellerTopicProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SellerTopicPortImpl implements SellerTopicPort {
+
+    private final SellerTopicProperties sellerTopicProperties;
+
+    @Override
+    public String getSellerRegisterTopic(String version) {
+        return sellerTopicProperties.getSellerRegister().get(version);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/adaptor/out/OutboxRepositoryPortImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/adaptor/out/OutboxRepositoryPortImpl.java
@@ -1,0 +1,27 @@
+package com.smore.seller.infrastructure.adaptor.out;
+
+import com.smore.seller.application.port.out.OutboxRepositoryPort;
+import com.smore.seller.infrastructure.outbox.SellerOutbox;
+import com.smore.seller.infrastructure.outbox.SellerOutboxRepository;
+import java.time.Clock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryPortImpl implements OutboxRepositoryPort {
+
+    private final SellerOutboxRepository repository;
+    private final Clock clock;
+
+    @Override
+    public void saveOutBox(String topic, Long key, String payload) {
+        SellerOutbox sellerOutbox = new SellerOutbox(
+            topic,
+            key,
+            payload,
+            clock
+        );
+        repository.save(sellerOutbox);
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -36,7 +36,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerRegisterV1Topic() {
         return TopicBuilder.name("seller.register.v1")
-            .partitions(1)
+            .partitions(2)
             .replicas(3)
             .build();
     }
@@ -44,7 +44,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerDisabledV1Topic() {
         return TopicBuilder.name("seller.disabled.v1")
-            .partitions(1)
+            .partitions(2)
             .replicas(3)
             .build();
     }

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -36,7 +36,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerRegisterV1Topic() {
         return TopicBuilder.name("seller.register.v1")
-            .partitions(2)
+            .partitions(1)
             .replicas(3)
             .build();
     }
@@ -44,7 +44,7 @@ public class SellerKafkaTopicConfig {
     @Bean
     public NewTopic SellerDisabledV1Topic() {
         return TopicBuilder.name("seller.disabled.v1")
-            .partitions(2)
+            .partitions(1)
             .replicas(3)
             .build();
     }

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -1,6 +1,7 @@
 package com.smore.seller.infrastructure.kafka;
 
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,10 +11,12 @@ import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaAdmin;
 
 @Configuration
+@RequiredArgsConstructor
 public class SellerKafkaTopicConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+    private final SellerTopicProperties topicProperties;
 
     @Bean
     /*
@@ -35,7 +38,7 @@ public class SellerKafkaTopicConfig {
     // 판매자 상태변경과 등록은 자주 일어나는 이벤트는 아니기 때문에 파티션 2
     @Bean
     public NewTopic SellerRegisterV1Topic() {
-        return TopicBuilder.name("seller.register.v1")
+        return TopicBuilder.name(topicProperties.getSellerRegister().get("v1"))
             .partitions(2)
             .replicas(3)
             .build();

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerTopicProperties.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerTopicProperties.java
@@ -1,0 +1,17 @@
+package com.smore.seller.infrastructure.kafka;
+
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "topic.produce")
+@Component
+@Getter
+@Setter
+public class SellerTopicProperties {
+
+    private Map<String, String> sellerRegister;
+
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutbox.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutbox.java
@@ -1,4 +1,4 @@
-package com.smore.seller.infrastructure.persistence.jpa.entity;
+package com.smore.seller.infrastructure.outbox;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_seller_outbox")
@@ -28,11 +30,13 @@ public class SellerOutbox {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 발행될 카프카 토픽명
     private String eventType;
 
+    // partition key 로 사용 (kafka key)
     private Long memberId;
 
-    @Lob
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "json")
     private String payload;
 

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxDispatcher.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxDispatcher.java
@@ -1,0 +1,57 @@
+package com.smore.seller.infrastructure.outbox;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SellerOutboxDispatcher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final SellerOutboxRepository repository;
+    private final Clock clock;
+
+    private static final int MAX_RETRY = 3;
+
+    @Transactional
+    public void dispatch(SellerOutbox event) {
+        try {
+            var future = kafkaTemplate.send(
+                event.getEventType(),
+                event.getMemberId().toString(),
+                event.getPayload()
+            );
+
+            future.get();
+
+            repository.markSent(
+                event.getId(),
+                LocalDateTime.now(clock)
+            );
+        } catch (Exception e) {
+            handleFailure(event, e);
+        }
+    }
+    private void handleFailure(SellerOutbox event, Exception e) {
+
+        int retry = event.getRetryCount() + 1;
+        if (retry >= MAX_RETRY) {
+            repository.markFailed(
+                event.getId(),
+                e.getMessage(),
+                LocalDateTime.now(clock)
+            );
+        } else {
+            repository.updateRetry(
+                event.getId(),
+                retry,
+                e.getMessage(),
+                LocalDateTime.now(clock)
+            );
+        }
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxFetcher.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxFetcher.java
@@ -1,0 +1,29 @@
+package com.smore.seller.infrastructure.outbox;
+
+import com.smore.seller.infrastructure.outbox.SellerOutbox.MessageStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// 조회전용 계층
+@Component
+@RequiredArgsConstructor
+public class SellerOutboxFetcher {
+
+    private final SellerOutboxRepository sellerOutboxRepository;
+
+    public List<SellerOutbox> fetchPending() {
+
+        //region 동적으로 배치사이즈를 변경하고 싶으면 인자로 int batchSize 를 받아와서 사용
+//        Pageable pageable = PageRequest.of(0, batchSize);
+//
+//        sellerOutboxRepository.findByStatusOrderByIdAsc(
+//            MessageStatus.PENDING, pageable
+//        );
+        //endregion
+
+        return sellerOutboxRepository.findTop100ByStatusOrderByIdAsc(
+            MessageStatus.PENDING
+        );
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxProcessor.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxProcessor.java
@@ -1,0 +1,32 @@
+package com.smore.seller.infrastructure.outbox;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SellerOutboxProcessor {
+
+    private final SellerOutboxFetcher fetcher;
+    private final SellerOutboxDispatcher dispatcher;
+
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 2000)
+    public void process() {
+        List<SellerOutbox> events = fetcher.fetchPending();
+        for (SellerOutbox event : events) {
+            try {
+                dispatcher.dispatch(event);
+            } catch (Exception e) {
+                // 절대 throw 하지 않음
+                log.error("[Outbox] Unexpected error while processing id={}", event.getId(), e);
+            }
+        }
+    }
+
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxRepository.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/outbox/SellerOutboxRepository.java
@@ -1,0 +1,35 @@
+package com.smore.seller.infrastructure.outbox;
+
+import com.smore.seller.infrastructure.outbox.SellerOutbox.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SellerOutboxRepository extends CrudRepository<SellerOutbox, Long> {
+
+    List<SellerOutbox> findTop100ByStatusOrderByIdAsc(
+        MessageStatus messageStatus
+    );
+
+    // batchSize 를 동적으로 변환하고 싶다면 사용
+    List<SellerOutbox> findByStatusOrderByIdAsc(
+        SellerOutbox.MessageStatus status,
+        Pageable pageable
+    );
+
+    @Modifying
+    @Query("UPDATE SellerOutbox o SET o.status = 'SENT', o.processedAt = :processedAt, o.errorMessage = null WHERE o.id = :id")
+    void markSent(Long id, LocalDateTime processedAt);
+
+    @Modifying
+    @Query("UPDATE SellerOutbox o SET o.retryCount = :retry, o.errorMessage = :error, o.processedAt = :processedAt WHERE o.id = :id")
+    void updateRetry(Long id, int retry, String error, LocalDateTime processedAt);
+
+    @Modifying
+    @Query("UPDATE SellerOutbox o SET o.status = 'FAILED', o.errorMessage = :error, o.processedAt = :processedAt WHERE o.id = :id")
+    void markFailed(Long id, String error, LocalDateTime processedAt);
+
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/SellerRepositoryImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/SellerRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.smore.seller.infrastructure.persistence.jpa.entity.SellerJpa;
 import com.smore.seller.infrastructure.persistence.jpa.mapper.SellerJpaMapper;
 import com.smore.seller.infrastructure.persistence.jpa.repository.SellerJpaRepository;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -34,9 +35,8 @@ public class SellerRepositoryImpl implements SellerRepository {
 
     @Override
     public Seller findById(UUID id) {
-        SellerJpa sellerJpa = repository.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Seller with id " + id + " not found"));
-        return mapper.toDomain(sellerJpa);
+        Optional<SellerJpa> sellerJpa = repository.findById(id);
+        return sellerJpa.map(mapper::toDomain)
+            .orElse(null);
     }
-
 }

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/entity/SellerJpa.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/entity/SellerJpa.java
@@ -2,6 +2,7 @@ package com.smore.seller.infrastructure.persistence.jpa.entity;
 
 import com.smore.seller.domain.enums.SellerStatus;
 import com.smore.seller.infrastructure.persistence.jpa.vo.MoneyEmbeddable;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,6 +28,7 @@ public class SellerJpa {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
+    @Column(unique = true)
     private Long memberId;
     private String accountNum;
     @Enumerated(EnumType.STRING)

--- a/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/repository/SellerOutboxRepository.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/persistence/jpa/repository/SellerOutboxRepository.java
@@ -1,8 +1,0 @@
-package com.smore.seller.infrastructure.persistence.jpa.repository;
-
-import com.smore.seller.infrastructure.persistence.jpa.entity.SellerOutbox;
-import org.springframework.data.repository.CrudRepository;
-
-public interface SellerOutboxRepository extends CrudRepository<SellerOutbox, Long> {
-
-}

--- a/member/src/main/java/com/smore/seller/presentation/web/SellerController.java
+++ b/member/src/main/java/com/smore/seller/presentation/web/SellerController.java
@@ -74,6 +74,7 @@ public class SellerController {
         return ResponseEntity.ok(ApiResponse.ok("거절 성공"));
     }
 
+    // TODO: 이미 승인된 Seller 중복 승인할 경우 예외처리 필요
     @PostMapping("/{id}/approve")
     public ResponseEntity<CommonResponse<?>> approveSeller(
         @RequestHeader("X-User-Role") String role,

--- a/member/src/main/resources/application-dev.yml
+++ b/member/src/main/resources/application-dev.yml
@@ -15,6 +15,38 @@ spring:
         initial-interval: 1000
         multiplier: 1.5
 
+  kafka:
+    # 로컬에서 Docker로 띄운 브로커 외부 포트에 맞춰 설정 (docker-compose의 EXTERNAL 매핑)
+    bootstrap-servers: kafka-1:9092,kafka-2:9092,kafka-3:9092
+
+    consumer:
+      group-id: member-service-group
+      # offset 커밋 기록이 삭제되었거나, 브로커에서 보관중인 로그범위에서 오프셋이 유효하지 않은 경우
+      # 어디서부터 메시지를 읽기 시작할지 정해주는 설정
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      properties:
+        isolation.level: read_committed # 트랜잭션 메시지 읽기 안전성
+      # key 는 String 으로 역직렬화
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      # value 는 Json java 객체로 역직렬화 하겠다
+      # properties 추가 설정이나 ConsumerFactory 에서 추가 설정 필요
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+    listener:
+      # 필수: @KafkaListener 에서 Acknowledgment 사용 가능
+      # MANUAL 수동 커밋 모드
+      ack-mode: MANUAL
+      # 컨슈머 스레드 개수 (옵션)
+      concurrency: 3
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      # 브로커의 리더 + 모든 ISR 에 쓰기 성공 후 ACK
+      acks: all
+      retries: 3
+
 eureka:
   client:
     register-with-eureka: true
@@ -23,3 +55,15 @@ eureka:
       defaultZone: http://eureka-server:18800/eureka/
   instance:
     prefer-ip-address: true
+
+seller:
+  topic:
+    seller-register:
+      v1: seller.register.v1
+      v2: seller.register.v2
+
+member:
+  topic:
+    seller-register:
+      v1: seller.register.v1
+      v2: seller.register.v2

--- a/member/src/main/resources/application-local.yml
+++ b/member/src/main/resources/application-local.yml
@@ -76,3 +76,9 @@ springdoc:
 eureka:
   client:
     enabled: false
+
+topic:
+  produce:
+    seller-register:
+      v1: seller.register.v1
+      v2: seller.register.v2

--- a/member/src/main/resources/application-local.yml
+++ b/member/src/main/resources/application-local.yml
@@ -77,8 +77,14 @@ eureka:
   client:
     enabled: false
 
-topic:
-  produce:
+seller:
+  topic:
+    seller-register:
+      v1: seller.register.v1
+      v2: seller.register.v2
+
+member:
+  topic:
     seller-register:
       v1: seller.register.v1
       v2: seller.register.v2

--- a/member/src/main/resources/application-local.yml
+++ b/member/src/main/resources/application-local.yml
@@ -51,7 +51,7 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       # value 는 Json java 객체로 역직렬화 하겠다
       # properties 추가 설정이나 ConsumerFactory 에서 추가 설정 필요
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
     listener:
       # 필수: @KafkaListener 에서 Acknowledgment 사용 가능

--- a/member/src/main/resources/data.sql
+++ b/member/src/main/resources/data.sql
@@ -4,11 +4,12 @@ VALUES
     (1, 'ADMIN', 'admin@example.com', '$2a$10$sFHAFHXkl0ohQkv3uCuOAOmsfZgI/Aca4FH6hnkKP6jj1Fqw1Prg2', 'admin', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
     (2, 'SELLER', 'seller_pending@example.com', 'hashed-seller-password', 'seller_pending', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
     (3, 'SELLER', 'seller_active@example.com', 'hashed-seller-password', 'seller_active', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
-    (4, 'SELLER', 'seller_inactive@example.com', 'hashed-seller-password', 'seller_inactive', 0, 'INACTIVE', NOW(), NOW(), NULL, NULL),
+    (4, 'CONSUMER', 'consumer_changed_from_seller4@example.com', 'hashed-consumer-password', 'consumer_from4', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
     (5, 'SELLER', 'seller_deleted@example.com', 'hashed-seller-password', 'seller_deleted', 1, 'DELETED', NOW(), NOW(), NOW(), 1),
     (6, 'SELLER', 'seller_banned@example.com', 'hashed-seller-password', 'seller_banned', 2, 'BANNED', NOW(), NOW(), NOW(), 1),
     (7, 'CONSUMER', 'consumer_active@example.com', 'hashed-consumer-password', 'consumer_active', 0, 'ACTIVE', NOW(), NOW(), NULL, NULL),
-    (8, 'CONSUMER', 'consumer_inactive@example.com', 'hashed-consumer-password', 'consumer_inactive', 0, 'INACTIVE', NOW(), NOW(), NULL, NULL)
+    (8, 'CONSUMER', 'consumer_inactive@example.com', 'hashed-consumer-password', 'consumer_inactive', 0, 'INACTIVE', NOW(), NOW(), NULL, NULL),
+    (9, 'SELLER', 'seller_inactive@example.com', 'hashed-seller-password', 'seller_inactive', 0, 'INACTIVE', NOW(), NOW(), NULL, NULL)
 ON CONFLICT DO NOTHING;
 
 -- Seed sellers by status (linked to seller members above)
@@ -16,12 +17,12 @@ INSERT INTO p_seller (id, member_id, account_num, status, created_at, updated_at
 VALUES
     ('00000000-0000-0000-0000-000000000001', 2, '111-11-111111', 'PENDING', NOW(), NOW(), NULL, NULL),
     ('00000000-0000-0000-0000-000000000002', 3, '222-22-222222', 'ACTIVE', NOW(), NOW(), NULL, NULL),
-    ('00000000-0000-0000-0000-000000000003', 4, '333-33-333333', 'INACTIVE', NOW(), NOW(), NULL, NULL),
+    ('00000000-0000-0000-0000-000000000003', 9, '333-33-333333', 'INACTIVE', NOW(), NOW(), NULL, NULL),
     ('00000000-0000-0000-0000-000000000004', 5, '444-44-444444', 'DELETED', NOW(), NOW(), NOW(), 1),
     ('00000000-0000-0000-0000-000000000005', 6, '555-55-555555', 'BANNED', NOW(), NOW(), NOW(), 1)
 ON CONFLICT DO NOTHING;
---
--- -- Seed: seller outbox pending 230 rows
+
+-- Seed: seller outbox pending 230 rows
 -- INSERT INTO p_seller_outbox (
 --     created_at,
 --     error_message,
@@ -42,3 +43,29 @@ ON CONFLICT DO NOTHING;
 --     0,
 --     'PENDING'
 -- FROM generate_series(1, 230) g;
+
+-- Event seed: member id 4 changed to consumer
+INSERT INTO p_seller_outbox (
+    created_at,
+    error_message,
+    event_type,
+    member_id,
+    payload,
+    processed_at,
+    retry_count,
+    status
+)
+VALUES (
+    NOW(),
+    NULL,
+    'seller.register.v1',
+    4,
+    json_build_object(
+        'memberId', 4,
+        'idempotencyKey', '00000000-0000-0000-0000-000000000004',
+        'createdAt', NOW()
+    )::json,
+    NULL,
+    0,
+    'PENDING'
+);

--- a/member/src/main/resources/data.sql
+++ b/member/src/main/resources/data.sql
@@ -20,3 +20,25 @@ VALUES
     ('00000000-0000-0000-0000-000000000004', 5, '444-44-444444', 'DELETED', NOW(), NOW(), NOW(), 1),
     ('00000000-0000-0000-0000-000000000005', 6, '555-55-555555', 'BANNED', NOW(), NOW(), NOW(), 1)
 ON CONFLICT DO NOTHING;
+--
+-- -- Seed: seller outbox pending 230 rows
+-- INSERT INTO p_seller_outbox (
+--     created_at,
+--     error_message,
+--     event_type,
+--     member_id,
+--     payload,
+--     processed_at,
+--     retry_count,
+--     status
+-- )
+-- SELECT
+--     NOW(),
+--     NULL,
+--     'seller.register.v1',
+--     200000 + g,                             -- dummy member id
+--     json_build_object('seed', g)::json,     -- dummy payload
+--     NULL,
+--     0,
+--     'PENDING'
+-- FROM generate_series(1, 230) g;


### PR DESCRIPTION
## jwt 검증용 Member 내부서버 API 기능 추가
f7259184dd21e7af0653e63f4b8c970f46478dfd
- 내부서버용으로 반환은 간단하게 boolean 으로 처리
- 주석 처리된 부분은 공통응답으로 처리하게 변경 될시 활성화 시키려고 두었습니다

## gw 임시처리되어있던 jwt 검증 필터 활성화
92e5290e35e0b70bc0af6a869307e6d2aa31136c
- jwt 토큰이 없으면 바로 pass 됩니다 (jwt 존재 여부는 WhiteList 필터에서 검증 예정)
- docker 에서 테스트 완료