### PR TITLE
Order 주문 목록 조회 ( 동적 쿼리 )

### DIFF
--- a/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
@@ -2,9 +2,12 @@ package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Order;
 import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository {
 
@@ -13,6 +16,8 @@ public interface OrderRepository {
     Order findById(UUID orderId);
 
     Optional<Order> findByAllocationKeyAndUserId(UUID allocationKey, Long userId);
+
+    Optional<Order> findByIdIncludingDeleted(UUID orderId);
 
     Order save(Order order);
 
@@ -30,4 +35,6 @@ public interface OrderRepository {
         Integer refundedQuantity);
 
     int update(Order order);
+
+    int delete(UUID orderId, Long userId, LocalDateTime now);
 }

--- a/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OrderRepository.java
@@ -2,12 +2,12 @@ package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Order;
 import com.smore.order.domain.status.OrderStatus;
-import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderRepository {
 
@@ -20,6 +20,8 @@ public interface OrderRepository {
     Optional<Order> findByIdIncludingDeleted(UUID orderId);
 
     Order save(Order order);
+
+    Page<Order> findAll(Long userId, UUID productId, Pageable pageable);
 
     int markComplete(UUID orderId);
 

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -33,6 +33,7 @@ import com.smore.order.infrastructure.persistence.exception.UpdateOrderFailExcep
 import com.smore.order.presentation.dto.DeleteOrderResponse;
 import com.smore.order.presentation.dto.IsOrderCreatedResponse;
 import com.smore.order.presentation.dto.ModifyOrderResponse;
+import com.smore.order.presentation.dto.OrderInfo;
 import com.smore.order.presentation.dto.RefundResponse;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
@@ -467,6 +468,13 @@ public class OrderService {
             now,
             userId
         );
+    }
+
+    public OrderInfo searchOrderOne(UUID orderId) {
+
+        Order order = orderRepository.findById(orderId);
+
+        return OrderInfo.of(order);
     }
 
     // TODO: 나중에 클래스로 분리할 예정

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -28,7 +28,9 @@ import com.smore.order.domain.status.RefundStatus;
 import com.smore.order.domain.status.ServiceResult;
 import com.smore.order.domain.vo.Address;
 import com.smore.order.infrastructure.persistence.exception.CompleteOrderFailException;
+import com.smore.order.infrastructure.persistence.exception.NotFoundOrderException;
 import com.smore.order.infrastructure.persistence.exception.UpdateOrderFailException;
+import com.smore.order.presentation.dto.DeleteOrderResponse;
 import com.smore.order.presentation.dto.IsOrderCreatedResponse;
 import com.smore.order.presentation.dto.ModifyOrderResponse;
 import com.smore.order.presentation.dto.RefundResponse;
@@ -413,6 +415,57 @@ public class OrderService {
             command.getAddress().street(),
             command.getAddress().city(),
             command.getAddress().zipcode()
+        );
+    }
+
+    @Transactional
+    public DeleteOrderResponse delete(UUID orderId, Long userId) {
+
+        Optional<Order> content = orderRepository.findByIdIncludingDeleted(orderId);
+
+        if (content.isEmpty()) {
+            log.error("주문을 찾을 수 없습니다. orderId : {}", orderId);
+            throw new NotFoundOrderException("주문을 찾을 수 없습니다.");
+        }
+
+        Order order = content.get();
+
+        if (order.notEqualUserId(userId)) {
+            return DeleteOrderResponse.fail(
+                "주문자와 주문 삭제자가 일치하지 않습니다."
+            );
+        }
+
+        if (order.isDeleted()) {
+            return DeleteOrderResponse.success(
+                "이미 삭제된 주문입니다.",
+                order.getDeletedAt(),
+                order.getDeletedBy()
+            );
+        }
+
+        if (order.isUndeletable()) {
+            return DeleteOrderResponse.fail(
+                "삭제 가능한 상태가 아닙니다."
+            );
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        int updated = orderRepository.delete(
+            orderId,
+            userId,
+            now
+        );
+
+        if (updated == 0) {
+            log.error("동시 처리로 주문 삭제 실패 orderid : {}, method : {} ", orderId, "delete()");
+            throw new UpdateOrderFailException("동시 처리로 주문 삭제 실패");
+        }
+
+        return DeleteOrderResponse.success(
+            "주문 삭제에 성공했습니다.",
+            now,
+            userId
         );
     }
 

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -163,6 +163,14 @@ public class Order {
         return this.address.equals(address);
     }
 
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public boolean isUndeletable() {
+        return this.orderStatus != OrderStatus.CONFIRMED;
+    }
+
     private static Integer calculateTotalPrice(Integer price, Integer quantity) {
         return price * quantity;
     }

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -33,6 +33,10 @@ public class Order {
     private LocalDateTime confirmedAt;
     private LocalDateTime cancelledAt;
     private Address address;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private Long deletedBy;
 
     public static Order create(
         Long userId, UUID productId,
@@ -84,7 +88,11 @@ public class Order {
         LocalDateTime cancelledAt,
         String street,
         String city,
-        String zipcode
+        String zipcode,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt,
+        Long deletedBy
     ) {
 
         Product product = new Product(productId, productPrice);
@@ -107,6 +115,10 @@ public class Order {
             .confirmedAt(confirmedAt)
             .cancelledAt(cancelledAt)
             .address(address)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .deletedAt(deletedAt)
+            .deletedBy(deletedBy)
             .build();
     }
 
@@ -144,7 +156,7 @@ public class Order {
     }
 
     public boolean notEqualUserId(Long userId) {
-        return this.userId != userId;
+        return !this.userId.equals(userId);
     }
 
     public boolean equalAddress(Address address) {

--- a/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
+++ b/order/src/main/java/com/smore/order/domain/status/OrderStatus.java
@@ -9,6 +9,7 @@ public enum OrderStatus {
     PARTIALLY_REFUNDED("부분 환불"),
     REFUNDED("전체 환불"),
     CANCELLED("주문 취소"),
+    CONFIRMED("주문 확정")
     ;
 
     private final String description;

--- a/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
@@ -12,9 +12,53 @@ public class KafkaConfig {
     @Value("${topic.order.created}")
     private String createdOrderTopic;
 
+    @Value("${topic.order.completed}")
+    private String completedOrderTopic;
+
+    @Value("${topic.order.refund}")
+    private String refundRequestOrderTopic;
+
+    @Value("${topic.order.refund-success}")
+    private String refundSucceededOrderTopic;
+
+    @Value("${topic.order.refund-fail}")
+    private String refundFailedOrderTopic;
+
     @Bean
     public NewTopic orderCreatedTopic() {
         return TopicBuilder.name(createdOrderTopic)
+            .partitions(3)
+            .replicas(3)
+            .build();
+    }
+
+    @Bean
+    public NewTopic orderCompletedTopic() {
+        return TopicBuilder.name(completedOrderTopic)
+            .partitions(3)
+            .replicas(3)
+            .build();
+    }
+
+    @Bean
+    public NewTopic orderRefundRequestTopic() {
+        return TopicBuilder.name(refundRequestOrderTopic)
+            .partitions(3)
+            .replicas(3)
+            .build();
+    }
+
+    @Bean
+    public NewTopic orderRefundSucceededTopic() {
+        return TopicBuilder.name(refundSucceededOrderTopic)
+            .partitions(3)
+            .replicas(3)
+            .build();
+    }
+
+    @Bean
+    public NewTopic orderRefundFailedTopic() {
+        return TopicBuilder.name(refundFailedOrderTopic)
             .partitions(3)
             .replicas(3)
             .build();

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OrderMapper.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/mapper/OrderMapper.java
@@ -55,7 +55,11 @@ public final class OrderMapper {
             entity.getCancelledAt(),
             entity.getAddress().getStreet(),
             entity.getAddress().getCity(),
-            entity.getAddress().getZipcode()
+            entity.getAddress().getZipcode(),
+            entity.getCreatedAt(),
+            entity.getUpdatedAt(),
+            entity.getDeletedAt(),
+            entity.getDeletedBy()
         );
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepository.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepository.java
@@ -3,8 +3,18 @@ package com.smore.order.infrastructure.persistence.repository.order;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID>,
     OrderJpaRepositoryCustom {
 
+    @Query(
+    value ="""
+        SELECT * 
+        FROM p_order 
+        WHERE id = :id
+    """,
+    nativeQuery = true)
+    OrderEntity findByIdIncludingDeleted(@Param("id") UUID orderId);
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.smore.order.infrastructure.persistence.repository.order;
 import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.infrastructure.persistence.entity.order.Address;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -26,4 +27,6 @@ public interface OrderJpaRepositoryCustom {
         Integer refundedQuantity);
 
     int update(UUID orderId, Long userId, Address address);
+
+    int delete(UUID orderId, Long userId, LocalDateTime now);
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustom.java
@@ -6,12 +6,16 @@ import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderJpaRepositoryCustom {
 
     OrderEntity findByIdempotencyKey(UUID idempotencyKey);
 
     OrderEntity findByAllocationKeyAndUserId(UUID allocationKey, Long userId);
+
+    Page<OrderEntity> findAll(Long userId, UUID productId, Pageable pageable);
 
     int markComplete(UUID orderId, OrderStatus status);
 

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
@@ -2,15 +2,26 @@ package com.smore.order.infrastructure.persistence.repository.order;
 
 import static com.smore.order.infrastructure.persistence.entity.order.QOrderEntity.*;
 
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.infrastructure.persistence.entity.order.Address;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
 public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
@@ -39,6 +50,33 @@ public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
                 orderEntity.userId.eq(userId)
             )
             .fetchOne();
+    }
+
+    public Page<OrderEntity> findAll(Long userId, UUID productId, Pageable pageable) {
+
+        List<OrderSpecifier> orderSpecifiers = getOrderSpecifiers(pageable);
+
+        List<OrderEntity> content = queryFactory
+            .select(orderEntity)
+            .from(orderEntity)
+            .where(
+                userIdEq(userId),
+                productIdEq(productId)
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(orderEntity.count())
+            .from(orderEntity)
+            .where(
+                userIdEq(userId),
+                productIdEq(productId)
+            );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     @Override
@@ -172,5 +210,34 @@ public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
         em.clear();
 
         return (int) updated;
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        return userId != null ? orderEntity.userId.eq(userId) : null;
+    }
+
+    private BooleanExpression productIdEq(UUID productId) {
+        return productId != null ? orderEntity.product.productId.eq(productId) : null;
+    }
+
+    private static List<OrderSpecifier> getOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        for (Sort.Order o : pageable.getSort()) {
+
+            // isAscending는 오름차순이면 true, 내림차순이면 false 반환
+            com.querydsl.core.types.Order direction = o.isAscending() ?
+                com.querydsl.core.types.Order.ASC : com.querydsl.core.types.Order.DESC;
+
+            String property = o.getProperty();
+
+            PathBuilder<?> path = new PathBuilder<>(OrderEntity.class, orderEntity.getMetadata());
+
+            ComparableExpression<?> expr =
+                path.getComparable(o.getProperty(), Comparable.class);
+
+            orderSpecifiers.add(new OrderSpecifier(direction, expr));
+        }
+        return orderSpecifiers;
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderJpaRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.smore.order.domain.status.OrderStatus;
 import com.smore.order.infrastructure.persistence.entity.order.Address;
 import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -143,6 +144,27 @@ public class OrderJpaRepositoryCustomImpl implements OrderJpaRepositoryCustom {
             .where(
                 orderEntity.id.eq(orderId),
                 orderEntity.userId.eq(userId)
+            )
+            .execute();
+
+        em.flush();
+        em.clear();
+
+        return (int) updated;
+    }
+
+    @Override
+    public int delete(UUID orderId, Long userId, LocalDateTime now) {
+        long updated = queryFactory
+            .update(orderEntity)
+            .set(orderEntity.deletedBy, userId)
+            .set(orderEntity.deletedAt, now)
+            .where(
+                orderEntity.id.eq(orderId),
+                orderEntity.userId.eq(userId),
+                orderEntity.orderStatus.eq(OrderStatus.CONFIRMED),
+                orderEntity.deletedAt.isNull(),
+                orderEntity.deletedBy.isNull()
             )
             .execute();
 

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOrderFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOrderException;
 import com.smore.order.infrastructure.persistence.mapper.OrderMapper;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
@@ -67,6 +68,14 @@ public class OrderRepositoryImpl implements OrderRepository {
 
         OrderEntity entity = orderJpaRepository
             .findByAllocationKeyAndUserId(allocationKey, userId);
+
+        return Optional.ofNullable(entity).map(OrderMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Order> findByIdIncludingDeleted(UUID orderId) {
+
+        OrderEntity entity = orderJpaRepository.findByIdIncludingDeleted(orderId);
 
         return Optional.ofNullable(entity).map(OrderMapper::toDomain);
     }
@@ -139,5 +148,10 @@ public class OrderRepositoryImpl implements OrderRepository {
         );
 
         return orderJpaRepository.update(order.getId(), order.getUserId(), newAddress);
+    }
+
+    @Override
+    public int delete(UUID orderId, Long userId, LocalDateTime now) {
+        return orderJpaRepository.delete(orderId, userId, now);
     }
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/order/OrderRepositoryImpl.java
@@ -8,12 +8,15 @@ import com.smore.order.infrastructure.persistence.entity.order.OrderEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOrderFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOrderException;
 import com.smore.order.infrastructure.persistence.mapper.OrderMapper;
+
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Slf4j(topic = "OrderRepositoryImpl")
@@ -78,6 +81,14 @@ public class OrderRepositoryImpl implements OrderRepository {
         OrderEntity entity = orderJpaRepository.findByIdIncludingDeleted(orderId);
 
         return Optional.ofNullable(entity).map(OrderMapper::toDomain);
+    }
+
+    @Override
+    public Page<Order> findAll(Long userId, UUID productId, Pageable pageable) {
+
+        Page<OrderEntity> orderEntityPage = orderJpaRepository.findAll(userId, productId, pageable);
+
+        return orderEntityPage.map(OrderMapper::toDomain);
     }
 
     @Override

--- a/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
+++ b/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
@@ -31,4 +31,10 @@ public interface ExternalOrderController {
         @PathVariable UUID orderId,
         @Valid @RequestBody ModifyOrderRequest request
     );
+
+    ResponseEntity<CommonResponse<?>> delete(
+        @RequestHeader("X-User-Id") Long requesterId,
+        @RequestHeader("X-User-Role") String role,
+        @PathVariable UUID orderId
+    );
 }

--- a/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
+++ b/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,7 +54,12 @@ public interface ExternalOrderController {
         @RequestHeader("X-User-Role") String role,
         @RequestParam(required = false) Long userId,
         @RequestParam(required = false) UUID productId,
-        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+        @PageableDefault(size = 20)
+        @SortDefault.SortDefaults({
+            @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC),
+            @SortDefault(sort = "orderedAt", direction = Sort.Direction.DESC),
+            @SortDefault(sort = "totalAmount", direction = Sort.Direction.DESC)
+        })
         Pageable pageable
     );
 }

--- a/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
+++ b/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
@@ -7,10 +7,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface ExternalOrderController {
 
@@ -42,5 +46,14 @@ public interface ExternalOrderController {
         @RequestHeader("X-User-Id") Long requesterId,
         @RequestHeader("X-User-Role") String role,
         @PathVariable UUID orderId
+    );
+
+    ResponseEntity<CommonResponse<?>> searchOrderList(
+        @RequestHeader("X-User-Id") Long requesterId,
+        @RequestHeader("X-User-Role") String role,
+        @RequestParam(required = false) Long userId,
+        @RequestParam(required = false) UUID productId,
+        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable
     );
 }

--- a/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
+++ b/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderController.java
@@ -37,4 +37,10 @@ public interface ExternalOrderController {
         @RequestHeader("X-User-Role") String role,
         @PathVariable UUID orderId
     );
+
+    ResponseEntity<CommonResponse<?>> searchOrderOne(
+        @RequestHeader("X-User-Id") Long requesterId,
+        @RequestHeader("X-User-Role") String role,
+        @PathVariable UUID orderId
+    );
 }

--- a/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderControllerV1.java
+++ b/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderControllerV1.java
@@ -8,6 +8,7 @@ import com.smore.order.application.dto.ModifyOrderCommand;
 import com.smore.order.application.dto.RefundCommand;
 import com.smore.order.application.service.OrderService;
 import com.smore.order.presentation.auth.OrderRole;
+import com.smore.order.presentation.dto.DeleteOrderResponse;
 import com.smore.order.presentation.dto.IsOrderCreatedResponse;
 import com.smore.order.presentation.dto.ModifyOrderRequest;
 import com.smore.order.presentation.dto.ModifyOrderResponse;
@@ -18,6 +19,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -100,6 +102,25 @@ public class ExternalOrderControllerV1 implements ExternalOrderController {
         );
 
         ModifyOrderResponse response = orderService.modify(command);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @DeleteMapping("/api/v1/external/orders/{orderId}")
+    public ResponseEntity<CommonResponse<?>> delete(
+        @RequestHeader("X-User-Id") Long requesterId,
+        @RequestHeader("X-User-Role") String role,
+        @PathVariable UUID orderId
+    ) {
+
+        OrderRole orderRole = from(role);
+
+        if (orderRole.isNotAny(CONSUMER, SELLER, ADMIN)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("5403", "접근 권한이 없습니다."));
+        }
+
+        DeleteOrderResponse response = orderService.delete(orderId, requesterId);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderControllerV1.java
+++ b/order/src/main/java/com/smore/order/presentation/api/external/ExternalOrderControllerV1.java
@@ -12,6 +12,7 @@ import com.smore.order.presentation.dto.DeleteOrderResponse;
 import com.smore.order.presentation.dto.IsOrderCreatedResponse;
 import com.smore.order.presentation.dto.ModifyOrderRequest;
 import com.smore.order.presentation.dto.ModifyOrderResponse;
+import com.smore.order.presentation.dto.OrderInfo;
 import com.smore.order.presentation.dto.RefundRequest;
 import com.smore.order.presentation.dto.RefundResponse;
 import jakarta.validation.Valid;
@@ -121,6 +122,25 @@ public class ExternalOrderControllerV1 implements ExternalOrderController {
         }
 
         DeleteOrderResponse response = orderService.delete(orderId, requesterId);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/api/v1/external/orders/{orderId}")
+    public ResponseEntity<CommonResponse<?>> searchOrderOne(
+        @RequestHeader("X-User-Id") Long requesterId,
+        @RequestHeader("X-User-Role") String role,
+        @PathVariable UUID orderId
+    ) {
+
+        OrderRole orderRole = from(role);
+
+        if (orderRole.isNotAny(CONSUMER, SELLER, ADMIN)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("5403", "접근 권한이 없습니다."));
+        }
+
+        OrderInfo response = orderService.searchOrderOne(orderId);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/order/src/main/java/com/smore/order/presentation/dto/DeleteOrderResponse.java
+++ b/order/src/main/java/com/smore/order/presentation/dto/DeleteOrderResponse.java
@@ -1,0 +1,40 @@
+package com.smore.order.presentation.dto;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeleteOrderResponse {
+
+    private final Boolean success;
+    private final String message;
+    private String deletedAt;
+    private Long deletedBy;
+
+    public static DeleteOrderResponse success(
+        String message,
+        LocalDateTime deletedAt,
+        Long deletedBy
+    ) {
+        return DeleteOrderResponse.builder()
+            .success(true)
+            .message(message)
+            .deletedAt(String.valueOf(deletedAt))
+            .deletedBy(deletedBy)
+            .build();
+    }
+
+    public static DeleteOrderResponse fail(
+        String message
+    ) {
+        return DeleteOrderResponse.builder()
+            .success(false)
+            .message(message)
+            .build();
+    }
+}

--- a/order/src/main/java/com/smore/order/presentation/dto/OrderInfo.java
+++ b/order/src/main/java/com/smore/order/presentation/dto/OrderInfo.java
@@ -1,0 +1,54 @@
+package com.smore.order.presentation.dto;
+
+import com.smore.order.domain.model.Order;
+import com.smore.order.domain.status.OrderStatus;
+import com.smore.order.domain.vo.Address;
+import com.smore.order.domain.vo.Product;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderInfo {
+
+    private UUID orderId;
+    private Long userId;
+    private Product product;
+    private Integer quantity;
+    private Integer totalAmount;
+    private Integer refundedAmount;
+    private OrderStatus orderStatus;
+    private LocalDateTime orderedAt;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private Address address;
+
+    public static OrderInfo of(Order order) {
+
+        if (order == null) {
+            return null;
+        }
+
+        Product product = order.getProduct();
+        Address address = order.getAddress();
+
+        return OrderInfo.builder()
+            .orderId(order.getId())
+            .userId(order.getUserId())
+            .product(product)
+            .quantity(order.getQuantity())
+            .totalAmount(order.getTotalAmount())
+            .refundedAmount(order.getRefundedAmount())
+            .orderStatus(order.getOrderStatus())
+            .orderedAt(order.getOrderedAt())
+            .confirmedAt(order.getConfirmedAt())
+            .cancelledAt(order.getCancelledAt())
+            .address(address)
+            .build();
+    }
+}


### PR DESCRIPTION
### 변경된 내용 
- **주문 목록을 조회하는 엔드포인트 구현 (컨트롤러)**
- **주문 목록을 조회하는 서비스 로직 구현 (서비스)**
  - 유효한 정렬 기준인지 검사하는 로직 추가

- **주문 목록을 조회하는 레포지토리 로직 구현 (레포지토리)**
  - userId, productId 등 특정 값이 있을 때 동적으로 쿼리가 추가되도록 구현 
  - 정렬 기준이 들어오게 되면 정렬 기준에 따라 정렬되도록 구현 

### 커밋
2c192d5
[feat(Order) : 주문 목록 조회 서비스 로직 추가 (가능한 Sort 검증, Repository 메서드에 작업 위임)](https://github.com/FocusCrew-4/Smore/pull/55/commits/2c192d5ce6f820d8ba18ccc7a651cb18db3966a0)

---

3eb26e7
[feat(Order) : 주문 목록 조회 QueryDSL 코드 추가 (동적 쿼리, 동적 정렬 추가)](https://github.com/FocusCrew-4/Smore/pull/55/commits/3eb26e744144471da300cdc515a2b410f3064fa6)

---

8f45891
[feat(Order) : 주문 목록 조회 컨트롤러 메서드 정의 및 구현](https://github.com/FocusCrew-4/Smore/pull/55/commits/8f45891498cd37c2f789093ddbfca6f650af18cf)

---

e154bca
[fix(Order) : 인터페이스와 구현체 애너테이션 불일치 수정](https://github.com/FocusCrew-4/Smore/pull/55/commits/e154bca75e2055190ec426c35b9311c255d730d6)

---

8ed1242
[feat(Order) : 카프카에 토픽 추가되도록 설정](https://github.com/FocusCrew-4/Smore/pull/55/commits/8ed1242218ee841c626481c1212fbea07087c3b5)