### PR TITLE
feat: 상품 삭제 기능 및 상태 필드 누락분 추가

### DIFF
--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -37,7 +37,8 @@ public class ProductService {
                 req.getPrice(),
                 req.getStock(),
                 req.getSaleType(),
-                req.getThresholdForAuction()
+                req.getThresholdForAuction(),
+                req.getStatus()
         );
 
         productRepository.save(product);
@@ -103,5 +104,19 @@ public class ProductService {
         product.changeStatus(req.getStatus());
 
         return new ProductResponse(product);
+    }
+
+    @Transactional
+    public void deleteProduct(UUID productId, Long requesterId) {
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        // 이미 삭제된 상품 처리
+        if (product.getDeletedAt() != null) {
+            throw new IllegalStateException("이미 삭제된 상품입니다.");
+        }
+
+        product.softDelete(requesterId);
     }
 }

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -1,6 +1,7 @@
 package com.smore.product.domain.entity;
 
 import jakarta.persistence.*;
+import jdk.jshell.Snippet;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -55,7 +56,8 @@ public class Product {
             BigDecimal price,
             int stock,
             SaleType saleType,
-            Integer thresholdForAuction
+            Integer thresholdForAuction,
+            ProductStatus status
     ) {
         LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
 
@@ -68,7 +70,7 @@ public class Product {
                 .stock(stock)
                 .saleType(saleType)
                 .thresholdForAuction(thresholdForAuction)
-                .status(ProductStatus.ON_SALE)
+                .status(status)
                 .createdAt(now)
                 .updatedAt(now)
                 .build();
@@ -81,7 +83,8 @@ public class Product {
             Integer stock,
             UUID categoryId,
             SaleType saleType,
-            Integer thresholdForAuction
+            Integer thresholdForAuction,
+            ProductStatus status
     ) {
         if (name != null) this.name = name;
         if (description != null) this.description = description;
@@ -90,6 +93,7 @@ public class Product {
         if (categoryId != null) this.categoryId = categoryId;
         if (saleType != null) this.saleType = saleType;
         if (thresholdForAuction != null) this.thresholdForAuction = thresholdForAuction;
+        if (status != null) this.status = status;
 
         this.updatedAt = LocalDateTime.now(Clock.systemUTC());
     }
@@ -130,5 +134,6 @@ public class Product {
 
     public void changeStatus(ProductStatus status) {
         this.status = status;
+        this.updatedAt = LocalDateTime.now(Clock.systemUTC());
     }
 }

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
@@ -69,4 +69,13 @@ public class ProductController {
                 ApiResponse.ok(productService.updateProductStatus(productId, request))
         );
     }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<CommonResponse<Void>> deleteProduct(
+            @PathVariable UUID productId,
+            @RequestHeader("X-User-Id") Long requesterId
+    ) {
+        productService.deleteProduct(productId, requesterId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
 }

--- a/product/src/main/java/com/smore/product/presentation/dto/request/CreateProductRequest.java
+++ b/product/src/main/java/com/smore/product/presentation/dto/request/CreateProductRequest.java
@@ -1,5 +1,6 @@
 package com.smore.product.presentation.dto.request;
 
+import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.domain.entity.SaleType;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -36,6 +37,9 @@ public class CreateProductRequest {
 
     @NotNull(message = "판매 유형은 필수입니다.")
     private SaleType saleType;
+
+    @NotNull(message = "상품 판매 상태는 필수입니다.")
+    private ProductStatus status;
 
     // LIMITED_TO_AUCTION일 때는 서비스에서 추가 검증
     @Min(value = 1, message = "경매 전환 기준은 1 이상이어야 합니다.")

--- a/product/src/main/java/com/smore/product/presentation/dto/request/UpdateProductRequest.java
+++ b/product/src/main/java/com/smore/product/presentation/dto/request/UpdateProductRequest.java
@@ -1,5 +1,6 @@
 package com.smore.product.presentation.dto.request;
 
+import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.domain.entity.SaleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,8 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.util.UUID;
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateProductRequest {
     private String name;
     private String description;
@@ -16,4 +19,5 @@ public class UpdateProductRequest {
     private UUID categoryId;
     private SaleType saleType;
     private Integer thresholdForAuction;
+    private ProductStatus status;
 }


### PR DESCRIPTION
## 개요
상품 도메인에 삭제 기능을 추가하고, 기존에 누락되어 있던 status 필드를 보완했습니다.

## 주요 변경 사항
- ProductService에 상품 삭제 기능(`deleteProduct`) 구현
- ProductRepository에 삭제 관련 메서드 추가
- Product 엔티티의 status 관련 누락된 필드/매핑 보완
- UpdateProductStatusRequest / UpdateProductRequest 등 DTO에 status 필드 추가

## 목적
- 상품 상태 변경 시 누락된 필드로 인해 생기던 예외 상황 방지
- 관리자가 정상적으로 상품을 제거할 수 있는 기능 제공
- 전체 상품 흐름에서 상태 일관성 확보