### PR TITLE
feat: 특정 상품 판매 기록 조회 기능 추가

### DIFF
--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -1,6 +1,8 @@
 package com.smore.product.application.service;
 
 import com.smore.product.domain.entity.ProductStatus;
+import com.smore.product.domain.sale.dto.ProductSaleResponse;
+import com.smore.product.domain.sale.repository.ProductSaleRepository;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -14,12 +16,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductSaleRepository productSaleRepository;
 
     @Transactional
     public ProductResponse createProduct(CreateProductRequest req) {
@@ -118,5 +122,16 @@ public class ProductService {
         }
 
         product.softDelete(requesterId);
+    }
+
+    public List<ProductSaleResponse> getProductSales(UUID productId) {
+
+        // 상품 존재 여부 체크
+        productSaleRepository.findByProductId(productId);
+//                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        return productSaleRepository.findByProductId(productId).stream()
+                .map(ProductSaleResponse::new)
+                .toList();
     }
 }

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -37,7 +37,8 @@ public class ProductService {
                 req.getPrice(),
                 req.getStock(),
                 req.getSaleType(),
-                req.getThresholdForAuction()
+                req.getThresholdForAuction(),
+                req.getStatus()
         );
 
         productRepository.save(product);
@@ -103,5 +104,19 @@ public class ProductService {
         product.changeStatus(req.getStatus());
 
         return new ProductResponse(product);
+    }
+
+    @Transactional
+    public void deleteProduct(UUID productId, Long requesterId) {
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        // 이미 삭제된 상품 처리
+        if (product.getDeletedAt() != null) {
+            throw new IllegalStateException("이미 삭제된 상품입니다.");
+        }
+
+        product.softDelete(requesterId);
     }
 }

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -1,6 +1,7 @@
 package com.smore.product.domain.entity;
 
 import jakarta.persistence.*;
+import jdk.jshell.Snippet;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -55,7 +56,8 @@ public class Product {
             BigDecimal price,
             int stock,
             SaleType saleType,
-            Integer thresholdForAuction
+            Integer thresholdForAuction,
+            ProductStatus status
     ) {
         LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
 
@@ -68,7 +70,7 @@ public class Product {
                 .stock(stock)
                 .saleType(saleType)
                 .thresholdForAuction(thresholdForAuction)
-                .status(ProductStatus.ON_SALE)
+                .status(status)
                 .createdAt(now)
                 .updatedAt(now)
                 .build();
@@ -81,7 +83,8 @@ public class Product {
             Integer stock,
             UUID categoryId,
             SaleType saleType,
-            Integer thresholdForAuction
+            Integer thresholdForAuction,
+            ProductStatus status
     ) {
         if (name != null) this.name = name;
         if (description != null) this.description = description;
@@ -90,6 +93,7 @@ public class Product {
         if (categoryId != null) this.categoryId = categoryId;
         if (saleType != null) this.saleType = saleType;
         if (thresholdForAuction != null) this.thresholdForAuction = thresholdForAuction;
+        if (status != null) this.status = status;
 
         this.updatedAt = LocalDateTime.now(Clock.systemUTC());
     }
@@ -130,5 +134,6 @@ public class Product {
 
     public void changeStatus(ProductStatus status) {
         this.status = status;
+        this.updatedAt = LocalDateTime.now(Clock.systemUTC());
     }
 }

--- a/product/src/main/java/com/smore/product/domain/sale/dto/ProductSaleResponse.java
+++ b/product/src/main/java/com/smore/product/domain/sale/dto/ProductSaleResponse.java
@@ -1,0 +1,24 @@
+package com.smore.product.domain.sale.dto;
+
+import com.smore.product.domain.sale.entity.ProductSale;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class ProductSaleResponse {
+
+    private final UUID id;
+    private final int quantity;
+    private final BigDecimal priceAtPurchase;
+    private final LocalDateTime createdAt;
+
+    public ProductSaleResponse(ProductSale sale) {
+        this.id = sale.getId();
+        this.quantity = sale.getQuantity();
+        this.priceAtPurchase = sale.getPriceAtPurchase();
+        this.createdAt = sale.getCreatedAt();
+    }
+}

--- a/product/src/main/java/com/smore/product/domain/sale/entity/ProductSale.java
+++ b/product/src/main/java/com/smore/product/domain/sale/entity/ProductSale.java
@@ -1,0 +1,37 @@
+package com.smore.product.domain.sale.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product_sale")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProductSale {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(columnDefinition = "UUID")
+    private UUID productId;
+
+    private int quantity;
+
+    private BigDecimal priceAtPurchase;
+
+    private LocalDateTime createdAt;
+}

--- a/product/src/main/java/com/smore/product/domain/sale/repository/ProductSaleRepository.java
+++ b/product/src/main/java/com/smore/product/domain/sale/repository/ProductSaleRepository.java
@@ -1,0 +1,13 @@
+package com.smore.product.domain.sale.repository;
+
+
+import com.smore.product.domain.sale.entity.ProductSale;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ProductSaleRepository extends JpaRepository<ProductSale, UUID> {
+
+    List<ProductSale> findByProductId(UUID productId);
+}

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.smore.product.presentation.controller;
 import com.smore.common.response.ApiResponse;
 import com.smore.common.response.CommonResponse;
 import com.smore.product.application.service.ProductService;
+import com.smore.product.domain.sale.dto.ProductSaleResponse;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -15,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -77,5 +79,13 @@ public class ProductController {
     ) {
         productService.deleteProduct(productId, requesterId);
         return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @GetMapping("/{productId}/sales")
+    public ResponseEntity<CommonResponse<List<ProductSaleResponse>>> getSales(
+            @PathVariable UUID productId
+    ) {
+        var response = productService.getProductSales(productId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
@@ -69,4 +69,13 @@ public class ProductController {
                 ApiResponse.ok(productService.updateProductStatus(productId, request))
         );
     }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<CommonResponse<Void>> deleteProduct(
+            @PathVariable UUID productId,
+            @RequestHeader("X-User-Id") Long requesterId
+    ) {
+        productService.deleteProduct(productId, requesterId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
 }

--- a/product/src/main/java/com/smore/product/presentation/dto/request/CreateProductRequest.java
+++ b/product/src/main/java/com/smore/product/presentation/dto/request/CreateProductRequest.java
@@ -1,5 +1,6 @@
 package com.smore.product.presentation.dto.request;
 
+import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.domain.entity.SaleType;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -36,6 +37,9 @@ public class CreateProductRequest {
 
     @NotNull(message = "판매 유형은 필수입니다.")
     private SaleType saleType;
+
+    @NotNull(message = "상품 판매 상태는 필수입니다.")
+    private ProductStatus status;
 
     // LIMITED_TO_AUCTION일 때는 서비스에서 추가 검증
     @Min(value = 1, message = "경매 전환 기준은 1 이상이어야 합니다.")

--- a/product/src/main/java/com/smore/product/presentation/dto/request/UpdateProductRequest.java
+++ b/product/src/main/java/com/smore/product/presentation/dto/request/UpdateProductRequest.java
@@ -1,5 +1,6 @@
 package com.smore.product.presentation.dto.request;
 
+import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.domain.entity.SaleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,8 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.util.UUID;
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateProductRequest {
     private String name;
     private String description;
@@ -16,4 +19,5 @@ public class UpdateProductRequest {
     private UUID categoryId;
     private SaleType saleType;
     private Integer thresholdForAuction;
+    private ProductStatus status;
 }


### PR DESCRIPTION
## 작업 내용
ProductSale 엔티티 추가 (p_product_sale 테이블 매핑)
특정 상품의 판매 기록 조회를 위한 ProductSaleRepository 구현
판매 기록 조회 DTO(ProductSaleResponse) 생성
ProductService에 판매기록 조회 로직 추가
ProductController에 /products/{productId}/sales GET API 추가