### PR TITLE
feat: 상품 재고 변동 기록 조회 기능 추가

### DIFF
--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -3,6 +3,8 @@ package com.smore.product.application.service;
 import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.domain.sale.dto.ProductSaleResponse;
 import com.smore.product.domain.sale.repository.ProductSaleRepository;
+import com.smore.product.domain.stock.dto.StockLogResponse;
+import com.smore.product.domain.stock.repository.StockLogRepository;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -24,6 +26,7 @@ import java.util.UUID;
 public class ProductService {
     private final ProductRepository productRepository;
     private final ProductSaleRepository productSaleRepository;
+    private final StockLogRepository stockLogRepository;
 
     @Transactional
     public ProductResponse createProduct(CreateProductRequest req) {
@@ -132,6 +135,17 @@ public class ProductService {
 
         return productSaleRepository.findByProductId(productId).stream()
                 .map(ProductSaleResponse::new)
+                .toList();
+    }
+
+    public List<StockLogResponse> getStockLogs(UUID productId) {
+
+        productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        return stockLogRepository.findByProductIdOrderByCreatedAtDesc(productId)
+                .stream()
+                .map(StockLogResponse::new)
                 .toList();
     }
 }

--- a/product/src/main/java/com/smore/product/domain/stock/dto/StockLogResponse.java
+++ b/product/src/main/java/com/smore/product/domain/stock/dto/StockLogResponse.java
@@ -1,0 +1,23 @@
+package com.smore.product.domain.stock.dto;
+
+import com.smore.product.domain.stock.entity.StockLog;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class StockLogResponse {
+
+    private final UUID id;
+    private final int beforeStock;
+    private final int afterStock;
+    private final LocalDateTime createdAt;
+
+    public StockLogResponse(StockLog log) {
+        this.id = log.getId();
+        this.beforeStock = log.getBeforeStock();
+        this.afterStock = log.getAfterStock();
+        this.createdAt = log.getCreatedAt();
+    }
+}

--- a/product/src/main/java/com/smore/product/domain/stock/entity/StockLog.java
+++ b/product/src/main/java/com/smore/product/domain/stock/entity/StockLog.java
@@ -1,0 +1,28 @@
+package com.smore.product.domain.stock.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_stock_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class StockLog {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(columnDefinition = "UUID", nullable = false)
+    private UUID productId;
+
+    private int beforeStock;
+    private int afterStock;
+
+    private LocalDateTime createdAt;
+}

--- a/product/src/main/java/com/smore/product/domain/stock/repository/StockLogRepository.java
+++ b/product/src/main/java/com/smore/product/domain/stock/repository/StockLogRepository.java
@@ -1,0 +1,12 @@
+package com.smore.product.domain.stock.repository;
+
+import com.smore.product.domain.stock.entity.StockLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface StockLogRepository extends JpaRepository<StockLog, UUID> {
+
+    List<StockLog> findByProductIdOrderByCreatedAtDesc(UUID productId);
+}

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.smore.common.response.ApiResponse;
 import com.smore.common.response.CommonResponse;
 import com.smore.product.application.service.ProductService;
 import com.smore.product.domain.sale.dto.ProductSaleResponse;
+import com.smore.product.domain.stock.dto.StockLogResponse;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -86,6 +87,13 @@ public class ProductController {
             @PathVariable UUID productId
     ) {
         var response = productService.getProductSales(productId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+    @GetMapping("/{productId}/stock-logs")
+    public ResponseEntity<CommonResponse<List<StockLogResponse>>> getStockLogs(
+            @PathVariable UUID productId
+    ) {
+        var response = productService.getStockLogs(productId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }


### PR DESCRIPTION
#### 주요 변경 사항
- StockLog 엔티티 추가
12a7924012cf9c6ae9f4ef034d62ece27b860a0e

- StockLogRepository 생성
40dacf148d704e4f14cae6bb6d613731b88b24d1

- StockLogResponse DTO 추가
a1a723870985dcb58b8fa77e11528ba018dabf70

- ProductService에 재고 로그 조회 로직 추가
55d116bafef092e1811a5f2c3e235457eec3ebaa

- ProductController에 `/products/{productId}/stock-logs` API 추가
416a9f1b1cf307189ec68e7d47355f5fbaf7408f

#### 테스트
- DB에 p_stock_log 데이터 삽입 후 정상 조회 확인