### PR TITLE
feat: 페이로드 추가 및 이벤트 수신 구현

### DIFF
--- a/product/build.gradle
+++ b/product/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:postgresql'
     runtimeOnly 'com.h2database:h2'

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -3,6 +3,8 @@ package com.smore.product.application.service;
 import com.smore.product.domain.entity.ProductStatus;
 import com.smore.product.domain.sale.dto.ProductSaleResponse;
 import com.smore.product.domain.sale.repository.ProductSaleRepository;
+import com.smore.product.domain.stock.dto.StockLogResponse;
+import com.smore.product.domain.stock.repository.StockLogRepository;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -24,6 +26,7 @@ import java.util.UUID;
 public class ProductService {
     private final ProductRepository productRepository;
     private final ProductSaleRepository productSaleRepository;
+    private final StockLogRepository stockLogRepository;
 
     @Transactional
     public ProductResponse createProduct(CreateProductRequest req) {
@@ -132,6 +135,17 @@ public class ProductService {
 
         return productSaleRepository.findByProductId(productId).stream()
                 .map(ProductSaleResponse::new)
+                .toList();
+    }
+
+    public List<StockLogResponse> getStockLogs(UUID productId) {
+
+        productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        return stockLogRepository.findByProductIdOrderByCreatedAtDesc(productId)
+                .stream()
+                .map(StockLogResponse::new)
                 .toList();
     }
 }

--- a/product/src/main/java/com/smore/product/application/service/ProductService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductService.java
@@ -5,6 +5,7 @@ import com.smore.product.domain.sale.dto.ProductSaleResponse;
 import com.smore.product.domain.sale.repository.ProductSaleRepository;
 import com.smore.product.domain.stock.dto.StockLogResponse;
 import com.smore.product.domain.stock.repository.StockLogRepository;
+import com.smore.product.infrastructure.consumer.dto.BidLimitedSaleFinishedEvent;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -147,5 +148,15 @@ public class ProductService {
                 .stream()
                 .map(StockLogResponse::new)
                 .toList();
+    }
+
+    public void applyFinishedSale(BidLimitedSaleFinishedEvent event) {
+        Product product = productRepository.findById(event.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("상품 없음"));
+
+        product.decreaseStock(event.getSoldQuantity());
+
+        productRepository.save(product);
+        // 여기서 StockLog 남기고 싶으면 나중에 추가
     }
 }

--- a/product/src/main/java/com/smore/product/domain/entity/Product.java
+++ b/product/src/main/java/com/smore/product/domain/entity/Product.java
@@ -136,4 +136,17 @@ public class Product {
         this.status = status;
         this.updatedAt = LocalDateTime.now(Clock.systemUTC());
     }
+
+    public void decreaseStock(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("차감 수량은 0보다 커야 합니다.");
+        }
+
+        if (this.stock < quantity) {
+            throw new IllegalStateException("재고가 부족합니다.");
+        }
+
+        this.stock -= quantity;
+        this.updatedAt = LocalDateTime.now(Clock.systemUTC());
+    }
 }

--- a/product/src/main/java/com/smore/product/domain/event/AuctionPendingStartEvent.java
+++ b/product/src/main/java/com/smore/product/domain/event/AuctionPendingStartEvent.java
@@ -1,0 +1,21 @@
+package com.smore.product.domain.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AuctionPendingStartEvent {
+
+    private Long sellerId;
+    private UUID productId;
+    private UUID categoryId;
+    private Long productPrice;
+    private int stock;
+
+    private UUID idempotencyKey;
+    private LocalDateTime createdAt;
+}

--- a/product/src/main/java/com/smore/product/domain/event/AuctionPendingStartEvent.java
+++ b/product/src/main/java/com/smore/product/domain/event/AuctionPendingStartEvent.java
@@ -3,6 +3,7 @@ package com.smore.product.domain.event;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -13,7 +14,7 @@ public class AuctionPendingStartEvent {
     private Long sellerId;
     private UUID productId;
     private UUID categoryId;
-    private Long productPrice;
+    private BigDecimal productPrice;
     private int stock;
 
     private UUID idempotencyKey;

--- a/product/src/main/java/com/smore/product/domain/event/AuctionStartedEvent.java
+++ b/product/src/main/java/com/smore/product/domain/event/AuctionStartedEvent.java
@@ -1,0 +1,19 @@
+package com.smore.product.domain.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AuctionStartedEvent {
+
+    private UUID productId;
+    private Duration biddingDuration;
+
+    private UUID idempotencyKey;
+    private LocalDateTime createdAt;
+}

--- a/product/src/main/java/com/smore/product/domain/event/BidLimitedSaleFinishedEvent.java
+++ b/product/src/main/java/com/smore/product/domain/event/BidLimitedSaleFinishedEvent.java
@@ -1,0 +1,20 @@
+package com.smore.product.domain.event;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class BidLimitedSaleFinishedEvent {
+
+    private UUID productId;
+    private Integer soldQuantity;
+    private UUID bidId;
+    private String idempotencyKey;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private LocalDateTime createdAt;
+
+    // JSON 역직렬화하려면 기본 생성자 필요
+    public BidLimitedSaleFinishedEvent() {}
+}

--- a/product/src/main/java/com/smore/product/domain/event/LimitedSalePendingStartEvent.java
+++ b/product/src/main/java/com/smore/product/domain/event/LimitedSalePendingStartEvent.java
@@ -1,0 +1,23 @@
+package com.smore.product.domain.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class LimitedSalePendingStartEvent {
+
+    private UUID productId;
+    private UUID categoryId;
+    private Long sellerId;
+    private BigDecimal productPrice;
+    private int stock;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+
+    private UUID idempotencyKey;
+}

--- a/product/src/main/java/com/smore/product/domain/stock/dto/StockLogResponse.java
+++ b/product/src/main/java/com/smore/product/domain/stock/dto/StockLogResponse.java
@@ -1,0 +1,23 @@
+package com.smore.product.domain.stock.dto;
+
+import com.smore.product.domain.stock.entity.StockLog;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class StockLogResponse {
+
+    private final UUID id;
+    private final int beforeStock;
+    private final int afterStock;
+    private final LocalDateTime createdAt;
+
+    public StockLogResponse(StockLog log) {
+        this.id = log.getId();
+        this.beforeStock = log.getBeforeStock();
+        this.afterStock = log.getAfterStock();
+        this.createdAt = log.getCreatedAt();
+    }
+}

--- a/product/src/main/java/com/smore/product/domain/stock/entity/StockLog.java
+++ b/product/src/main/java/com/smore/product/domain/stock/entity/StockLog.java
@@ -1,0 +1,28 @@
+package com.smore.product.domain.stock.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_stock_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class StockLog {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(columnDefinition = "UUID", nullable = false)
+    private UUID productId;
+
+    private int beforeStock;
+    private int afterStock;
+
+    private LocalDateTime createdAt;
+}

--- a/product/src/main/java/com/smore/product/domain/stock/repository/StockLogRepository.java
+++ b/product/src/main/java/com/smore/product/domain/stock/repository/StockLogRepository.java
@@ -1,0 +1,12 @@
+package com.smore.product.domain.stock.repository;
+
+import com.smore.product.domain.stock.entity.StockLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface StockLogRepository extends JpaRepository<StockLog, UUID> {
+
+    List<StockLog> findByProductIdOrderByCreatedAtDesc(UUID productId);
+}

--- a/product/src/main/java/com/smore/product/infrastructure/config/KafkaProducerConfig.java
+++ b/product/src/main/java/com/smore/product/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,32 @@
+package com.smore.product.infrastructure.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, org.springframework.kafka.support.serializer.JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/product/src/main/java/com/smore/product/infrastructure/consumer/BidLimitedSaleFinishedConsumer.java
+++ b/product/src/main/java/com/smore/product/infrastructure/consumer/BidLimitedSaleFinishedConsumer.java
@@ -1,0 +1,27 @@
+package com.smore.product.infrastructure.consumer;
+
+import com.smore.product.application.service.ProductService;
+import com.smore.product.infrastructure.consumer.dto.BidLimitedSaleFinishedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BidLimitedSaleFinishedConsumer {
+
+    private final ProductService productService;
+
+    @KafkaListener(topics = "bid.limitedSaleFinished.v1", groupId = "product-service")
+    public void handleLimitedSaleFinished(BidLimitedSaleFinishedEvent event) {
+
+        log.info("🎯 [Event Received] bid.limitedSaleFinished.v1 productId = {}", event.getProductId());
+
+        // TODO: 판매 수량 반영 로직
+        productService.applyFinishedSale(event);
+
+        log.info("처리 완료: {}", event);
+    }
+}

--- a/product/src/main/java/com/smore/product/infrastructure/consumer/dto/BidLimitedSaleFinishedEvent.java
+++ b/product/src/main/java/com/smore/product/infrastructure/consumer/dto/BidLimitedSaleFinishedEvent.java
@@ -1,0 +1,16 @@
+package com.smore.product.infrastructure.consumer.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class BidLimitedSaleFinishedEvent {
+    private UUID productId;
+    private Integer soldQuantity;
+    private UUID bidId;
+    private UUID idempotencyKey;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private LocalDateTime createdAt;
+}

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.smore.common.response.ApiResponse;
 import com.smore.common.response.CommonResponse;
 import com.smore.product.application.service.ProductService;
 import com.smore.product.domain.sale.dto.ProductSaleResponse;
+import com.smore.product.domain.stock.dto.StockLogResponse;
 import com.smore.product.presentation.dto.request.CreateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductRequest;
 import com.smore.product.presentation.dto.request.UpdateProductStatusRequest;
@@ -86,6 +87,13 @@ public class ProductController {
             @PathVariable UUID productId
     ) {
         var response = productService.getProductSales(productId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+    @GetMapping("/{productId}/stock-logs")
+    public ResponseEntity<CommonResponse<List<StockLogResponse>>> getStockLogs(
+            @PathVariable UUID productId
+    ) {
+        var response = productService.getStockLogs(productId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }


### PR DESCRIPTION
- bid.limitedSaleFinished.v1 이벤트 수신 Consumer 구현
- 이벤트 페이로드(BidLimitedSaleFinishedEvent) 정의
- Product 도메인에 decreaseStock 로직 추가
- ProductService에서 이벤트 기반 재고 차감 처리 흐름 적용