### PR TITLE
Bid 라이프사이클 스케줄러 구현 (SCHEDULED → ACTIVE → CLOSED → END)

### DIFF
--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/dto/RefundSucceededCommand.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/dto/RefundSucceededCommand.java
@@ -1,0 +1,48 @@
+package com.smore.bidcompetition.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefundSucceededCommand {
+    private final UUID orderId;
+    private final UUID refundId;
+    private final Long userId;
+    private final Integer quantity;
+    private final UUID allocationKey;
+    private final Integer refundAmount;
+    private final String orderStatus;
+    private final LocalDateTime publishedAt;
+
+    public static RefundSucceededCommand of(
+        UUID orderId,
+        UUID refundId,
+        Long userId,
+        Integer quantity,
+        UUID allocationKey,
+        Integer refundAmount,
+        String orderStatus,
+        LocalDateTime now
+    ) {
+        return RefundSucceededCommand.builder()
+            .orderId(orderId)
+            .refundId(refundId)
+            .userId(userId)
+            .quantity(quantity)
+            .allocationKey(allocationKey)
+            .refundAmount(refundAmount)
+            .orderStatus(orderStatus)
+            .publishedAt(now)
+            .build();
+    }
+
+    public boolean isRefunded() {
+        return this.orderStatus.equals("REFUNDED");
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/exception/BidConflictException.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/exception/BidConflictException.java
@@ -1,0 +1,21 @@
+package com.smore.bidcompetition.application.exception;
+
+import com.smore.bidcompetition.infrastructure.error.BidException;
+import com.smore.common.error.ErrorCode;
+
+public class BidConflictException extends BidException {
+
+    public BidConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return super.getErrorCode();
+    }
+
+    @Override
+    public String getTriggeredBy() {
+        return super.getTriggeredBy();
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/BidCompetitionRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/BidCompetitionRepository.java
@@ -14,7 +14,7 @@ public interface BidCompetitionRepository {
 
     BidCompetition save(BidCompetition bidCompetition);
 
-    int decreaseStock(UUID bidId, Integer quantity, LocalDateTime now);
+    int decreaseStock(UUID bidId, Integer quantity, LocalDateTime acceptedAt);
 
     int increaseStock(UUID bidId, Integer quantity);
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/BidCompetitionRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/BidCompetitionRepository.java
@@ -2,6 +2,7 @@ package com.smore.bidcompetition.application.repository;
 
 import com.smore.bidcompetition.domain.model.BidCompetition;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public interface BidCompetitionRepository {
@@ -12,9 +13,21 @@ public interface BidCompetitionRepository {
 
     BidCompetition findByIdForUpdate(UUID bidId);
 
+    List<UUID> findBidsToActivate(LocalDateTime now);
+
+    List<UUID> findBidsToClose(LocalDateTime now);
+
+    List<UUID> findBidsToEnd(LocalDateTime now, long closeGraceSeconds);
+
     BidCompetition save(BidCompetition bidCompetition);
 
     int decreaseStock(UUID bidId, Integer quantity, LocalDateTime acceptedAt);
 
     int increaseStock(UUID bidId, Integer quantity);
+
+    int bulkActivateByStartAt(List<UUID> ids, LocalDateTime now);
+
+    int bulkCloseByEndAt(List<UUID> ids, LocalDateTime now);
+
+    int bulkFinalizeByValidAt(List<UUID> ids, LocalDateTime now, long closeGraceSeconds);
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/BidInventoryLogRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/BidInventoryLogRepository.java
@@ -1,0 +1,11 @@
+package com.smore.bidcompetition.application.repository;
+
+import com.smore.bidcompetition.domain.model.BidInventoryLog;
+
+public interface BidInventoryLogRepository {
+
+    BidInventoryLog findByIdempotencyKey(String idempotencyKey);
+
+    BidInventoryLog saveAndFlush(BidInventoryLog log);
+
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/WinnerRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/WinnerRepository.java
@@ -1,6 +1,8 @@
 package com.smore.bidcompetition.application.repository;
 
 import com.smore.bidcompetition.domain.model.Winner;
+import com.smore.bidcompetition.domain.status.WinnerStatus;
+import java.util.Collection;
 import java.util.UUID;
 
 public interface WinnerRepository {
@@ -13,5 +15,5 @@ public interface WinnerRepository {
 
     Winner save(Winner winner);
 
-    int markCancelled(UUID bidId, UUID allocationKey, Long version);
+    int markCancelled(UUID bidId, UUID allocationKey, Collection<WinnerStatus> statuses, Long version);
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
@@ -81,6 +81,8 @@ public class BidCompetitionService {
     @Transactional
     public BidResponse competition(CompetitionCommand command) {
 
+        LocalDateTime now = LocalDateTime.now(clock);
+
         Winner winner = winnerRepository.findByIdempotencyKey(command.getIdempotencyKey());
 
         if (winner != null) {
@@ -98,7 +100,6 @@ public class BidCompetitionService {
         // 비관락
         BidCompetition bid = bidCompetitionRepository.findByIdForUpdate(command.getBidId());
 
-        LocalDateTime now = LocalDateTime.now(clock);
         LocalDateTime expireAt = now.plusSeconds(validDurationSeconds);
 
         // 경쟁 상태 점검

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
@@ -161,6 +161,28 @@ public class BidCompetitionService {
             command.getZipcode()
         );
 
+        String idempotencyKey = InventoryChangeType.RESERVE.idempotencyKey(
+            String.valueOf(allocationKey)
+        );
+
+        Integer delta = command.getQuantity();
+
+        Integer stockBefore = bid.getStock();
+        Integer stockAfter = stockBefore - delta;
+
+        BidInventoryLog log = BidInventoryLog.create(
+            bid.getId(),
+            savedWinner.getId(),
+            InventoryChangeType.RESERVE,
+            stockBefore,
+            stockAfter,
+            delta,
+            idempotencyKey,
+            now
+        );
+
+        bidInventoryLogRepository.saveAndFlush(log);
+
 
         Outbox outbox = Outbox.create(
             AggregateType.BID,

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
@@ -251,6 +251,8 @@ public class BidCompetitionService {
             return;
         }
 
+        BidCompetition bid = bidCompetitionRepository.findByIdForUpdate(winner.getBidId());
+
         int updated = winnerRepository.markCancelled(
             winner.getBidId(),
             command.getAllocationKey(),
@@ -262,6 +264,41 @@ public class BidCompetitionService {
             log.error("동시성 충돌로 인해 작업을 처리하지 못했습니다. allocationKey : {}", command.getAllocationKey());
             throw new WinnerConflictException(BidErrorCode.WINNER_CONFLICT);
         }
+
+        Integer delta = winner.getQuantity();
+        Integer stockBefore = bid.getStock();
+        Integer stockAfter = stockBefore + delta;
+
+        // 로그 기록 필요
+        BidInventoryLog inventoryLog = BidInventoryLog.create(
+            winner.getBidId(),
+            winner.getId(),
+            InventoryChangeType.EXPIRED,
+            stockBefore,
+            stockAfter,
+            delta,
+            InventoryChangeType.EXPIRED.idempotencyKey(String.valueOf(winner.getAllocationKey())),
+            LocalDateTime.now(clock)
+        );
+
+        try {
+            bidInventoryLogRepository.saveAndFlush(inventoryLog);
+        } catch (DataIntegrityViolationException e) {
+            String message = e.getMostSpecificCause() != null
+                ? e.getMostSpecificCause().getMessage()
+                : e.getMessage();
+
+            if (message != null && message.contains(("uk_bid_idempotency_key"))) {
+                log.info("이미 처리된 실패 이벤트입니다. bidId={}, allocationKey={}",
+                    winner.getBidId(), command.getAllocationKey());
+                return;
+            }
+
+            log.error("재고 로그 저장 실패 (중복 아님). bidId={}, allocationKey={}, cause={}",
+                winner.getBidId(), command.getAllocationKey(), message, e);
+            throw e;
+        }
+
 
         updated = bidCompetitionRepository.increaseStock(winner.getBidId(), winner.getQuantity());
 

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidProcessor.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidProcessor.java
@@ -1,0 +1,84 @@
+package com.smore.bidcompetition.application.service;
+
+import com.smore.bidcompetition.application.repository.BidCompetitionRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j(topic = "bidProcessor")
+@Service
+@RequiredArgsConstructor
+public class BidProcessor {
+
+    @Value("${app.allocation.close-grace-seconds}")
+    private long closeGraceSeconds;
+
+    private final BidCompetitionRepository bidCompetitionRepository;
+    private final Clock clock;
+
+    @Async("bidTaskExecutor")
+    public void active() {
+        try {
+            LocalDateTime now = LocalDateTime.now(clock);
+
+            List<UUID> scheduledToActivateIds = bidCompetitionRepository
+                .findBidsToActivate(now);
+
+            if (scheduledToActivateIds.isEmpty()) {
+                log.info("[ACTIVE] 수행할 작업이 없습니다.");
+                return;
+            }
+
+            int activated = bidCompetitionRepository.bulkActivateByStartAt(scheduledToActivateIds, now);
+            log.info("{}개 중 {}개가 활성화 되었습니다", scheduledToActivateIds.size(), activated);
+        } catch (Exception e) {
+            log.error("active failed", e);
+        }
+    }
+
+    @Async("bidTaskExecutor")
+    public void close() {
+        try {
+            LocalDateTime now = LocalDateTime.now(clock);
+
+            List<UUID> activeToCloseIds = bidCompetitionRepository
+                .findBidsToClose(now);
+
+            if (activeToCloseIds.isEmpty()) {
+                log.info("[CLOSE] 수행할 작업이 없습니다.");
+                return;
+            }
+
+            int closed = bidCompetitionRepository.bulkCloseByEndAt(activeToCloseIds, now);
+            log.info("{}개 중 {}개가 종료 되었습니다", activeToCloseIds.size(), closed);
+        } catch (Exception e) {
+            log.error("close failed", e);
+        }
+    }
+
+    @Async("bidTaskExecutor")
+    public void end() {
+        try {
+            LocalDateTime now = LocalDateTime.now(clock);
+
+            List<UUID> closedToEndIds = bidCompetitionRepository
+                .findBidsToEnd(now, closeGraceSeconds);
+
+            if (closedToEndIds.isEmpty()) {
+                log.info("[END] 수행할 작업이 없습니다.");
+                return;
+            }
+
+            int finalized = bidCompetitionRepository.bulkFinalizeByValidAt(closedToEndIds, now, closeGraceSeconds);
+            log.info("{}개 중 {}개가 종료 되었습니다", closedToEndIds.size(), finalized);
+        } catch (Exception e) {
+            log.error("end failed", e);
+        }
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/model/BidInventoryLog.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/model/BidInventoryLog.java
@@ -1,0 +1,95 @@
+package com.smore.bidcompetition.domain.model;
+
+import com.smore.bidcompetition.domain.status.InventoryChangeType;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BidInventoryLog {
+    private UUID id;
+    private UUID bidId;
+    private UUID winnerId;
+    private InventoryChangeType changeType;
+    private Integer stockBefore;
+    private Integer stockAfter;
+    private Integer quantityDelta;
+    private String idempotencyKey;
+    private LocalDateTime createdAt;
+
+    public static BidInventoryLog create(
+        UUID bidId,
+        UUID winnerId,
+        InventoryChangeType changeType,
+        Integer stockBefore,
+        Integer stockAfter,
+        Integer quantityDelta,
+        String idempotencyKey,
+        LocalDateTime createdAt
+    ) {
+        if (bidId == null) throw new IllegalArgumentException("경쟁 아이디는 필수값입니다");
+        if (winnerId == null) throw new IllegalArgumentException("경쟁 승리 식별자는 필수값입니다");
+        if (changeType == null) throw new IllegalArgumentException("재고 변경 타입은 필수값입니다");
+        if (stockBefore == null) throw new IllegalArgumentException("재고 변경 전 수량은 필수값입니다");
+
+        if (quantityDelta == null) throw new IllegalArgumentException("재고 변경 수량은 필수값입니다");
+        if (stockAfter == null) throw new IllegalArgumentException("재고 변경 후 수량은 필수값입니다");
+
+        int expectedAfter = stockBefore.intValue() + quantityDelta.intValue();
+        if (stockAfter.intValue() != expectedAfter) throw new IllegalArgumentException("재고 변경 후 수량은 [재고 변경 전 수량 + 변경 수량]과 일치해야 합니다");
+        if (idempotencyKey == null || idempotencyKey.isBlank()) throw new IllegalArgumentException("idempotencyKey는 필수값입니다");
+        if (createdAt == null) throw new IllegalArgumentException("생성 시간은 필수값입니다");
+
+        return BidInventoryLog.builder()
+            .bidId(bidId)
+            .winnerId(winnerId)
+            .changeType(changeType)
+            .stockBefore(stockBefore)
+            .stockAfter(stockAfter)
+            .quantityDelta(quantityDelta)
+            .idempotencyKey(idempotencyKey)
+            .createdAt(createdAt)
+            .build();
+    }
+
+    public static BidInventoryLog of(
+        UUID id,
+        UUID bidId,
+        UUID winnerId,
+        InventoryChangeType changeType,
+        Integer stockBefore,
+        Integer stockAfter,
+        Integer quantityDelta,
+        String idempotencyKey,
+        LocalDateTime createdAt
+    ) {
+        if (id == null) throw new IllegalArgumentException("재고 로그 아이디는 필수값입니다");
+        if (bidId == null) throw new IllegalArgumentException("경쟁 아이디는 필수값입니다");
+        if (winnerId == null) throw new IllegalArgumentException("경쟁 승리 식별자는 필수값입니다");
+        if (changeType == null) throw new IllegalArgumentException("재고 변경 타입은 필수값입니다");
+        if (stockBefore == null) throw new IllegalArgumentException("재고 변경 전 수량은 필수값입니다");
+        if (stockAfter == null) throw new IllegalArgumentException("재고 변경 후 수량은 필수값입니다");
+        if (quantityDelta == null) throw new IllegalArgumentException("재고 변경 수량은 필수값입니다");
+        if (idempotencyKey == null) throw new IllegalArgumentException("idempotencyKey는 필수값입니다");
+        if (createdAt == null) throw new IllegalArgumentException("생성 시간은 필수값입니다");
+
+        return BidInventoryLog.builder()
+            .id(id)
+            .bidId(bidId)
+            .winnerId(winnerId)
+            .changeType(changeType)
+            .stockBefore(stockBefore)
+            .stockAfter(stockAfter)
+            .quantityDelta(quantityDelta)
+            .idempotencyKey(idempotencyKey)
+            .createdAt(createdAt)
+            .build();
+    }
+
+
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/model/Winner.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/model/Winner.java
@@ -114,4 +114,8 @@ public class Winner {
         return this.winnerStatus != WinnerStatus.PAYMENT_PENDING;
     }
 
+    public boolean isNotPaid() {
+        return !isPaid();
+    }
+
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/BidStatus.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/BidStatus.java
@@ -4,7 +4,8 @@ public enum BidStatus {
     SCHEDULED("시작 전"),
     ACTIVE("진행 중"),
     CLOSED("종료 됨"),
-    CANCELLED("취소 됨")
+    CANCELLED("취소 됨"),
+    END("종료됨")
     ;
 
     private final String description;

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/BidStatus.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/BidStatus.java
@@ -3,9 +3,9 @@ package com.smore.bidcompetition.domain.status;
 public enum BidStatus {
     SCHEDULED("시작 전"),
     ACTIVE("진행 중"),
-    CLOSED("종료 됨"),
-    CANCELLED("취소 됨"),
-    END("종료됨")
+    CLOSED("판매 종료"),
+    CANCELLED("취소"),
+    END("정산 종료")
     ;
 
     private final String description;

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/InventoryChangeType.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/InventoryChangeType.java
@@ -1,0 +1,34 @@
+package com.smore.bidcompetition.domain.status;
+
+public enum InventoryChangeType {
+
+    RESERVE("재고 예약", "RESERVE"),
+    EXPIRED("경쟁 만료", "EXPIRED"),
+    REFUND("환불", "REFUND")
+    ;
+
+    private static final String SEPARATOR = ":";
+
+    private final String description;
+    private final String prefix;
+
+    InventoryChangeType(String description, String prefix) {
+        this.description = description;
+        this.prefix = prefix;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String idempotencyKey(String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            throw new IllegalArgumentException("identifier must not be null or blank");
+        }
+        return prefix + SEPARATOR + identifier;
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/WinnerStatus.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/WinnerStatus.java
@@ -1,11 +1,16 @@
 package com.smore.bidcompetition.domain.status;
 
+import java.util.EnumSet;
+
 public enum WinnerStatus {
     PAYMENT_PENDING("결제 대기"),
     PAID("결제 완료"),
     EXPIRED("만료"),
     CANCELLED("취소")
     ;
+
+    public static final EnumSet<WinnerStatus> CANCELABLE_STATUSES =
+        EnumSet.of(PAYMENT_PENDING, PAID);
 
     private final String description;
 

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/AsyncConfig.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/AsyncConfig.java
@@ -23,4 +23,16 @@ public class AsyncConfig {
         return executor;
     }
 
+    @Bean(name = "bidTaskExecutor")
+    public Executor bidTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(3);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("bid-task");
+        executor.initialize();
+        return executor;
+    }
+
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/error/BidErrorCode.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/error/BidErrorCode.java
@@ -7,6 +7,7 @@ public enum BidErrorCode implements ErrorCode {
     NOT_FOUND_OUTBOX("71404", "Outbox를 찾을 수 없습니다."),
     NOT_FOUND_WINNER("72404", "Winner를 찾을 수 없습니다."),
 
+    BID_CONFLICT("70409", "Bid를 생성하던 도중 예외가 발생했습니다."),
     WINNER_CONFLICT("72409", "Winner를 생성하던 도중 예외가 발생했습니다."),
 
     CREATE_OUTBOX_CONFLICT("71409", "Outbox를 생성하던 도중 예외가 발생했습니다."),

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/entity/BidInventoryLogEntity.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/entity/BidInventoryLogEntity.java
@@ -1,0 +1,85 @@
+package com.smore.bidcompetition.infrastructure.persistence.entity;
+
+import com.smore.bidcompetition.domain.status.InventoryChangeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    name = "p_bid_inventory_log",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_bid_idempotency_key",
+        columnNames = {"bid_id", "idempotency_key"}
+    )
+)
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BidInventoryLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "bid_id", nullable = false, updatable = false)
+    private UUID bidId;
+
+    @Column(name = "winner_id", nullable = false, updatable = false)
+    private UUID winnerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inventory_change_type", nullable = false, updatable = false)
+    private InventoryChangeType changeType;
+
+    @Column(name = "stock_before", nullable = false, updatable = false)
+    private Integer stockBefore;
+
+    @Column(name = "stock_after", nullable = false, updatable = false)
+    private Integer stockAfter;
+
+    @Column(name = "quantity_delta", nullable = false, updatable = false)
+    private Integer quantityDelta;
+
+    @Column(name = "idempotency_key", nullable = false, updatable = false)
+    private String idempotencyKey;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static BidInventoryLogEntity create(
+        UUID bidId,
+        UUID winnerId,
+        InventoryChangeType changeType,
+        Integer stockBefore,
+        Integer stockAfter,
+        Integer quantityDelta,
+        String idempotencyKey,
+        LocalDateTime createdAt
+    ) {
+        return BidInventoryLogEntity.builder()
+            .bidId(bidId)
+            .winnerId(winnerId)
+            .changeType(changeType)
+            .stockBefore(stockBefore)
+            .stockAfter(stockAfter)
+            .quantityDelta(quantityDelta)
+            .idempotencyKey(idempotencyKey)
+            .createdAt(createdAt)
+            .build();
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/event/inbound/RefundSucceedEvent.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/event/inbound/RefundSucceedEvent.java
@@ -1,0 +1,21 @@
+package com.smore.bidcompetition.infrastructure.persistence.event.inbound;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RefundSucceedEvent {
+    private UUID orderId;
+    private UUID refundId;
+    private Long userId;
+    private Integer quantity;
+    private UUID allocationKey;
+    private Integer refundAmount;
+    private String status;
+    private LocalDateTime publishedAt;
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/mapper/BidInventoryLogMapper.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/mapper/BidInventoryLogMapper.java
@@ -1,0 +1,46 @@
+package com.smore.bidcompetition.infrastructure.persistence.mapper;
+
+import com.smore.bidcompetition.domain.model.BidInventoryLog;
+import com.smore.bidcompetition.infrastructure.persistence.entity.BidInventoryLogEntity;
+
+public final class BidInventoryLogMapper {
+
+    private BidInventoryLogMapper() {
+
+    }
+
+    public static BidInventoryLogEntity toEntityForCreate(BidInventoryLog log) {
+        if (log == null) {
+            return null;
+        }
+
+        return BidInventoryLogEntity.create(
+            log.getBidId(),
+            log.getWinnerId(),
+            log.getChangeType(),
+            log.getStockBefore(),
+            log.getStockAfter(),
+            log.getQuantityDelta(),
+            log.getIdempotencyKey(),
+            log.getCreatedAt()
+        );
+    }
+
+    public static BidInventoryLog toDomain(BidInventoryLogEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return BidInventoryLog.of(
+            entity.getId(),
+            entity.getBidId(),
+            entity.getWinnerId(),
+            entity.getChangeType(),
+            entity.getStockBefore(),
+            entity.getStockAfter(),
+            entity.getQuantityDelta(),
+            entity.getIdempotencyKey(),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionJpaRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.smore.bidcompetition.infrastructure.persistence.repository.bid;
 
 import com.smore.bidcompetition.infrastructure.persistence.entity.BidCompetitionEntity;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public interface BidCompetitionJpaRepositoryCustom {
@@ -10,7 +11,11 @@ public interface BidCompetitionJpaRepositoryCustom {
 
     BidCompetitionEntity findByIdForUpdate(UUID bidId);
 
-    int decreaseStock(UUID bidId, Integer quantity, LocalDateTime now);
+    List<UUID> findBidsToActivate(LocalDateTime now);
+
+    List<UUID> findBidsToClose(LocalDateTime now);
+
+    int decreaseStock(UUID bidId, Integer quantity, LocalDateTime acceptedAt);
 
     int increaseStock(UUID bidId, Integer quantity);
 

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionJpaRepositoryCustom.java
@@ -15,8 +15,15 @@ public interface BidCompetitionJpaRepositoryCustom {
 
     List<UUID> findBidsToClose(LocalDateTime now);
 
+    List<UUID> findBidsToEnd(LocalDateTime now, long closeGraceSeconds);
+
     int decreaseStock(UUID bidId, Integer quantity, LocalDateTime acceptedAt);
 
     int increaseStock(UUID bidId, Integer quantity);
 
+    int bulkActivateByStartAt(List<UUID> ids, LocalDateTime now);
+
+    int bulkCloseByEndAt(List<UUID> ids, LocalDateTime now);
+
+    int bulkFinalizeByValidAt(List<UUID> ids, LocalDateTime now, long closeGraceSeconds);
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionRepositoryImpl.java
@@ -61,8 +61,8 @@ public class BidCompetitionRepositoryImpl implements BidCompetitionRepository {
     }
 
     @Override
-    public int decreaseStock(UUID bidId, Integer quantity, LocalDateTime now) {
-        return bidCompetitionJpaRepository.decreaseStock(bidId, quantity, now);
+    public int decreaseStock(UUID bidId, Integer quantity, LocalDateTime acceptedAt) {
+        return bidCompetitionJpaRepository.decreaseStock(bidId, quantity, acceptedAt);
     }
 
     @Override

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/bid/BidCompetitionRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.smore.bidcompetition.infrastructure.persistence.entity.BidCompetition
 import com.smore.bidcompetition.infrastructure.persistence.exception.NotFoundBidException;
 import com.smore.bidcompetition.infrastructure.persistence.mapper.BidMapper;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,21 @@ public class BidCompetitionRepositoryImpl implements BidCompetitionRepository {
     }
 
     @Override
+    public List<UUID> findBidsToActivate(LocalDateTime now) {
+        return bidCompetitionJpaRepository.findBidsToActivate(now);
+    }
+
+    @Override
+    public List<UUID> findBidsToClose(LocalDateTime now) {
+        return bidCompetitionJpaRepository.findBidsToClose(now);
+    }
+
+    @Override
+    public List<UUID> findBidsToEnd(LocalDateTime now, long closeGraceSeconds) {
+        return bidCompetitionJpaRepository.findBidsToEnd(now, closeGraceSeconds);
+    }
+
+    @Override
     public BidCompetition findByIdForUpdate(UUID bidId) {
 
         BidCompetitionEntity entity = bidCompetitionJpaRepository.findByIdForUpdate(bidId);
@@ -68,5 +84,20 @@ public class BidCompetitionRepositoryImpl implements BidCompetitionRepository {
     @Override
     public int increaseStock(UUID bidId, Integer quantity) {
         return bidCompetitionJpaRepository.increaseStock(bidId, quantity);
+    }
+
+    @Override
+    public int bulkActivateByStartAt(List<UUID> ids, LocalDateTime now) {
+        return bidCompetitionJpaRepository.bulkActivateByStartAt(ids, now);
+    }
+
+    @Override
+    public int bulkCloseByEndAt(List<UUID> ids, LocalDateTime now) {
+        return bidCompetitionJpaRepository.bulkCloseByEndAt(ids, now);
+    }
+
+    @Override
+    public int bulkFinalizeByValidAt(List<UUID> ids, LocalDateTime now, long closeGraceSeconds) {
+        return bidCompetitionJpaRepository.bulkFinalizeByValidAt(ids, now, closeGraceSeconds);
     }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogJpaRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogJpaRepository.java
@@ -1,0 +1,10 @@
+package com.smore.bidcompetition.infrastructure.persistence.repository.inventorylog;
+
+import com.smore.bidcompetition.infrastructure.persistence.entity.BidInventoryLogEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BidInventoryLogJpaRepository extends JpaRepository<BidInventoryLogEntity, UUID>,
+    BidInventoryLogJpaRepositoryCustom {
+
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogJpaRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.smore.bidcompetition.infrastructure.persistence.repository.inventorylog;
+
+import com.smore.bidcompetition.infrastructure.persistence.entity.BidInventoryLogEntity;
+
+public interface BidInventoryLogJpaRepositoryCustom {
+
+    BidInventoryLogEntity findByIdempotencyKey(String idempotencyKey);
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogJpaRepositoryCustomImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogJpaRepositoryCustomImpl.java
@@ -1,0 +1,27 @@
+package com.smore.bidcompetition.infrastructure.persistence.repository.inventorylog;
+
+import static com.smore.bidcompetition.infrastructure.persistence.entity.QBidInventoryLogEntity.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.smore.bidcompetition.infrastructure.persistence.entity.BidInventoryLogEntity;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BidInventoryLogJpaRepositoryCustomImpl implements BidInventoryLogJpaRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public BidInventoryLogEntity findByIdempotencyKey(String idempotencyKey) {
+
+        return queryFactory
+            .select(bidInventoryLogEntity)
+            .from(bidInventoryLogEntity)
+            .where(
+                bidInventoryLogEntity.idempotencyKey.eq(idempotencyKey)
+            )
+            .fetchOne();
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/inventorylog/BidInventoryLogRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.smore.bidcompetition.infrastructure.persistence.repository.inventorylog;
+
+import com.smore.bidcompetition.application.repository.BidInventoryLogRepository;
+import com.smore.bidcompetition.domain.model.BidInventoryLog;
+import com.smore.bidcompetition.infrastructure.persistence.entity.BidInventoryLogEntity;
+import com.smore.bidcompetition.infrastructure.persistence.mapper.BidInventoryLogMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BidInventoryLogRepositoryImpl implements BidInventoryLogRepository {
+
+    private final BidInventoryLogJpaRepository bidInventoryLogJpaRepository;
+
+    @Override
+    public BidInventoryLog findByIdempotencyKey(String idempotencyKey) {
+
+        BidInventoryLogEntity entity = bidInventoryLogJpaRepository.findByIdempotencyKey(
+            idempotencyKey);
+
+        if (entity == null) return null;
+
+        return BidInventoryLogMapper.toDomain(entity);
+    }
+
+    @Override
+    public BidInventoryLog saveAndFlush(BidInventoryLog log) {
+        BidInventoryLogEntity entity = bidInventoryLogJpaRepository.saveAndFlush(BidInventoryLogMapper.toEntityForCreate(log));
+        return BidInventoryLogMapper.toDomain(entity);
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustom.java
@@ -1,6 +1,8 @@
 package com.smore.bidcompetition.infrastructure.persistence.repository.winner;
 
+import com.smore.bidcompetition.domain.status.WinnerStatus;
 import com.smore.bidcompetition.infrastructure.persistence.entity.WinnerEntity;
+import java.util.Collection;
 import java.util.UUID;
 
 public interface WinnerJpaRepositoryCustom {
@@ -11,5 +13,5 @@ public interface WinnerJpaRepositoryCustom {
 
     int winnerPaid(UUID allocationKey, UUID orderId, Long version);
 
-    int markCancelled(UUID bidId, UUID allocationKey, Long version);
+    int markCancelled(UUID bidId, UUID allocationKey, Collection<WinnerStatus> statuses, Long version);
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustomImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustomImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.smore.bidcompetition.domain.status.WinnerStatus;
 import com.smore.bidcompetition.infrastructure.persistence.entity.WinnerEntity;
 import jakarta.persistence.EntityManager;
+import java.util.Collection;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 
@@ -61,7 +62,7 @@ public class WinnerJpaRepositoryCustomImpl implements WinnerJpaRepositoryCustom{
     }
 
     @Override
-    public int markCancelled(UUID bidId, UUID allocationKey, Long version) {
+    public int markCancelled(UUID bidId, UUID allocationKey, Collection<WinnerStatus> statuses, Long version) {
         long updated = queryFactory
             .update(winnerEntity)
             .set(winnerEntity.winnerStatus, WinnerStatus.CANCELLED)
@@ -69,7 +70,7 @@ public class WinnerJpaRepositoryCustomImpl implements WinnerJpaRepositoryCustom{
             .where(
                 winnerEntity.bidId.eq(bidId),
                 winnerEntity.allocationKey.eq(allocationKey),
-                winnerEntity.winnerStatus.eq(WinnerStatus.PAYMENT_PENDING),
+                winnerEntity.winnerStatus.in(statuses),
                 winnerEntity.version.eq(version)
             )
             .execute();

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerRepositoryImpl.java
@@ -2,10 +2,12 @@ package com.smore.bidcompetition.infrastructure.persistence.repository.winner;
 
 import com.smore.bidcompetition.application.repository.WinnerRepository;
 import com.smore.bidcompetition.domain.model.Winner;
+import com.smore.bidcompetition.domain.status.WinnerStatus;
 import com.smore.bidcompetition.infrastructure.error.BidErrorCode;
 import com.smore.bidcompetition.infrastructure.persistence.entity.WinnerEntity;
 import com.smore.bidcompetition.infrastructure.persistence.exception.NotFoundWinnerException;
 import com.smore.bidcompetition.infrastructure.persistence.mapper.WinnerMapper;
+import java.util.Collection;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +56,7 @@ public class WinnerRepositoryImpl implements WinnerRepository {
     }
 
     @Override
-    public int markCancelled(UUID bidId, UUID allocationKey, Long version) {
-        return winnerJpaRepository.markCancelled(bidId, allocationKey, version);
+    public int markCancelled(UUID bidId, UUID allocationKey, Collection<WinnerStatus> statuses, Long version) {
+        return winnerJpaRepository.markCancelled(bidId, allocationKey, statuses, version);
     }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/BidScheduler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/BidScheduler.java
@@ -1,0 +1,24 @@
+package com.smore.bidcompetition.presentation.scheduler;
+
+import com.smore.bidcompetition.application.service.BidProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j(topic = "BidScheduler")
+@Service
+@RequiredArgsConstructor
+public class BidScheduler {
+
+    private final BidProcessor bidProcessor;
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void bidLifecycleScheduler() {
+
+        bidProcessor.active();
+        bidProcessor.close();
+        bidProcessor.end();
+
+    }
+}

--- a/bidcompetition/src/main/resources/application.yml
+++ b/bidcompetition/src/main/resources/application.yml
@@ -61,3 +61,4 @@ app:
   allocation:
     valid-duration: 180
     propagation-buffer-time: 60
+    close-grace-seconds : 600

--- a/order/src/main/java/com/smore/order/application/event/outbound/OrderRefundSucceededEvent.java
+++ b/order/src/main/java/com/smore/order/application/event/outbound/OrderRefundSucceededEvent.java
@@ -1,5 +1,6 @@
 package com.smore.order.application.event.outbound;
 
+import com.smore.order.domain.status.OrderStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -12,20 +13,27 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderRefundSucceededEvent implements OrderEvent {
     private final UUID orderId;
+    private final UUID refundId;
     private final Long userId;
+    private final Integer quantity;
     private final UUID allocationKey;
     private final Integer refundAmount;
+    private final String status;
     private final LocalDateTime publishedAt;
 
     public static OrderRefundSucceededEvent of(
-        UUID orderId, Long userId, UUID allocationKey, Integer refundAmount,
+        UUID orderId, UUID refundId, Long userId, Integer quantity,
+        UUID allocationKey, Integer refundAmount, OrderStatus status,
         LocalDateTime now) {
 
         return OrderRefundSucceededEvent.builder()
             .orderId(orderId)
+            .refundId(refundId)
             .userId(userId)
+            .quantity(quantity)
             .allocationKey(allocationKey)
             .refundAmount(refundAmount)
+            .status(String.valueOf(status))
             .publishedAt(now)
             .build();
     }

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -313,9 +313,12 @@ public class OrderService {
 
         OrderRefundSucceededEvent event = OrderRefundSucceededEvent.of(
             refund.getOrderId(),
+            refund.getId(),
             order.getUserId(),
+            refund.getRefundQuantity(),
             order.getIdempotencyKey(),
             command.getRefundAmount(),
+            status,
             LocalDateTime.now(clock)
         );
 


### PR DESCRIPTION
### 변경된 내용 
- `Bid`가 `CLOSED` 상태일 때도 재고 감소 쿼리가 정상 동작하도록 수정 
  - 애플리케이션 레벨에서 정상 시간 내에 요청을 보냈지만 쿼리 단계에서 `Bid`가 `CLOSED` 상태가 되면서 실패하는 문제 해결을 위함
  - 즉, 애플리케이션 레벨에서 통과된 요청은 재고 부족이 아닌 이상 정상적으로 처리도되록 수정

- Bid 라이프사이클 스케줄러 구현 

### 라이프사이클 스케줄러 시퀀스 다이어그램
<img width="1885" height="2771" alt="image" src="https://github.com/user-attachments/assets/c5b2d9be-9335-4a7c-8800-1fc5916b7e91" />

## 프로세스 상세 설명

### 1. 스케줄러 실행 (BidScheduler)

- `bidLifecycleScheduler` 메서드는 설정된 크론 표현식(**5분 주기**)에 따라 실행
- `BidProcessor`의 `active()`, `close()`, `end()` 메서드를 **순차적으로 호출**하여 입찰 상태를 관리

---

### 2. 입찰 활성화 (BidProcessor.active)

- **대상 조회 (`findBidsToActivate`)**
    - 현재 시간(`now`) 기준으로 **시작 시간이 지난 `SCHEDULED` 상태의 입찰 ID 목록**을 조회
- **일괄 업데이트 (`bulkActivateByStartAt`)**
    - 조회된 입찰이 있다면, 상태를 **`ACTIVE`로 일괄 변경(Bulk Update)**

---

### 3. 입찰 종료 (BidProcessor.close)

- **대상 조회 (`findBidsToClose`)**
    - 현재 시간(`now`) 기준으로 **종료 시간이 지난 `ACTIVE` 상태의 입찰 ID 목록**을 조회
- **일괄 업데이트 (`bulkCloseByEndAt`)**
    - 조회된 입찰이 있다면, 상태를 **`CLOSED`로 일괄 변경**
    - 이 상태에서는 **더 이상 입찰 참여가 불가능**

---

### 4. 입찰 최종 마감 (BidProcessor.end)

- **대상 조회 (`findBidsToEnd`)**
    - 종료 후 유예 시간(`closeGraceSeconds`)이 지난 **`CLOSED` 상태의 입찰 ID 목록**을 조회
- **일괄 업데이트 (`bulkFinalizeByValidAt`)**
    - 조회된 입찰이 있다면, 상태를 **`END`로 일괄 변경**하여
        **입찰 프로세스를 완전히 마무리**