### PR TITLE
feat: seller/settlementReqfailed

### DIFF
--- a/member/src/main/java/com/smore/seller/application/impl/CreditSellerMoneyImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/CreditSellerMoneyImpl.java
@@ -50,7 +50,7 @@ public class CreditSellerMoneyImpl implements CreditSellerMoney {
             throw new RuntimeException("찾는 회원이 존재하지 않습니다");
         }
 
-        target.settle(amount, clock);
+        target.creditBalanceFromSales(amount, clock);
         log.info("고객의 금액 증가: {}", target.getMoney());
 
         repository.save(target);

--- a/member/src/main/java/com/smore/seller/application/impl/CreditSellerMoneyImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/CreditSellerMoneyImpl.java
@@ -1,0 +1,58 @@
+package com.smore.seller.application.impl;
+
+import com.smore.seller.application.usecase.CreditSellerMoney;
+import com.smore.seller.domain.model.Seller;
+import com.smore.seller.domain.repository.SellerRepository;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.core.NoContentException;
+import java.math.BigDecimal;
+import java.time.Clock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.TransactionTimedOutException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class CreditSellerMoneyImpl implements CreditSellerMoney {
+
+    private final SellerRepository repository;
+    private final Clock clock;
+
+    // 트랜잭션을 너무 오래 잡고 있으면 안 됨
+    // 재시도 시간이 너무 길어지면 Kafka message 진행이 안될 수 있음
+    @Retryable(
+        retryFor = {
+            CannotAcquireLockException.class,
+            TransactionTimedOutException.class
+        },
+        noRetryFor = {
+            NoContentException.class,
+            IllegalArgumentException.class
+        },
+        maxAttempts = 4,
+        backoff = @Backoff(
+            delay = 200,
+            multiplier = 2,
+            maxDelay = 1000
+        )
+    )
+    @Override
+    public void credit(Long targetId, BigDecimal amount) {
+        Seller target =
+            repository.findByMemberId(targetId);
+        if (target == null) {
+            throw new RuntimeException("찾는 회원이 존재하지 않습니다");
+        }
+
+        target.settle(amount, clock);
+        log.info("고객의 금액 증가: {}", target.getMoney());
+
+        repository.save(target);
+    }
+}

--- a/member/src/main/java/com/smore/seller/application/impl/RequestSettlementImpl.java
+++ b/member/src/main/java/com/smore/seller/application/impl/RequestSettlementImpl.java
@@ -33,7 +33,7 @@ public class RequestSettlementImpl implements RequestSettlement {
             throw new NoContentException("Seller not found");
         }
 
-        findSeller.settle(command.amount(), clock);
+        findSeller.debitBalanceForSettlement(command.amount(), clock);
 
         var event
             = SellerSettlementV1Event.create(

--- a/member/src/main/java/com/smore/seller/application/port/in/InboxService.java
+++ b/member/src/main/java/com/smore/seller/application/port/in/InboxService.java
@@ -1,0 +1,7 @@
+package com.smore.seller.application.port.in;
+
+import java.util.UUID;
+
+public interface InboxService {
+    void processOnce(UUID idempotencyKey, Runnable function);
+}

--- a/member/src/main/java/com/smore/seller/application/usecase/CreditSellerMoney.java
+++ b/member/src/main/java/com/smore/seller/application/usecase/CreditSellerMoney.java
@@ -1,0 +1,7 @@
+package com.smore.seller.application.usecase;
+
+import java.math.BigDecimal;
+
+public interface CreditSellerMoney {
+    void credit(Long targetId, BigDecimal amount);
+}

--- a/member/src/main/java/com/smore/seller/domain/model/Seller.java
+++ b/member/src/main/java/com/smore/seller/domain/model/Seller.java
@@ -53,8 +53,13 @@ public class Seller {
         this.updatedAt = LocalDateTime.now(clock);
     }
 
-    public void settle(BigDecimal amount, Clock clock) {
+    public void debitBalanceForSettlement(BigDecimal amount, Clock clock) {
         this.money = this.money.minus(Money.of(amount));
+        this.updatedAt = LocalDateTime.now(clock);
+    }
+
+    public void creditBalanceFromSales(BigDecimal amount, Clock clock) {
+        this.money = this.money.add(Money.of(amount));
         this.updatedAt = LocalDateTime.now(clock);
     }
 }

--- a/member/src/main/java/com/smore/seller/infrastructure/inbox/InboxServiceImpl.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/inbox/InboxServiceImpl.java
@@ -1,0 +1,28 @@
+package com.smore.seller.infrastructure.inbox;
+
+import com.smore.seller.application.port.in.InboxService;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InboxServiceImpl implements InboxService {
+
+    private final SellerInboxRepository inboxRepository;
+
+    @Override
+    @Transactional
+    public void processOnce(UUID idempotencyKey, Runnable function) {
+        if (inboxRepository.existsByIdempotencyKey(idempotencyKey)) {
+            return;
+        }
+
+        function.run();
+
+        inboxRepository.save(
+            SellerInbox.success(idempotencyKey)
+        );
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/inbox/SellerInbox.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/inbox/SellerInbox.java
@@ -1,0 +1,34 @@
+package com.smore.seller.infrastructure.inbox;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SellerInbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private UUID idempotencyKey;
+
+    public static SellerInbox success(
+        UUID idempotencyKey
+    ) {
+        return new SellerInbox(
+            null,
+            idempotencyKey
+        );
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/inbox/SellerInbox.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/inbox/SellerInbox.java
@@ -1,9 +1,12 @@
 package com.smore.seller.infrastructure.inbox;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,12 +18,22 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(
+    name = "p_seller_inbox",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_p_seller_inbox_idempotency_key",
+            columnNames = {"idempotency_key"}
+        )
+    }
+)
 public class SellerInbox {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(unique = true)
     private UUID idempotencyKey;
 
     public static SellerInbox success(

--- a/member/src/main/java/com/smore/seller/infrastructure/inbox/SellerInboxRepository.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/inbox/SellerInboxRepository.java
@@ -1,0 +1,9 @@
+package com.smore.seller.infrastructure.inbox;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerInboxRepository extends JpaRepository<SellerInbox, UUID> {
+
+    boolean existsByIdempotencyKey(UUID idempotencyKey);
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerKafkaTopicConfig.java
@@ -59,4 +59,14 @@ public class SellerKafkaTopicConfig {
             .replicas(3)
             .build();
     }
+
+    // DLT 는 확장 고려 대상이 아니고 쌓이기 시작하면 시스템에 문제가 있는 부분이기 때문에
+    // 1 파티션 설정 또한 2 개의 레플리카를 운영함으로써 복제를 아예 안 하는 부분은 아니게 설정하였습니다
+    @Bean
+    public NewTopic SellerDeadLetterV1() {
+        return TopicBuilder.name("seller.deadLetter.v1")
+            .partitions(1)
+            .replicas(2)
+            .build();
+    }
 }

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerTopicProperties.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/SellerTopicProperties.java
@@ -14,5 +14,6 @@ public class SellerTopicProperties {
 
     private Map<String, String> sellerRegister;
     private Map<String, String> sellerSettlement;
+    private Map<String, String> sellerDeadLetter;
 
 }

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/SellerKafkaListener.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/SellerKafkaListener.java
@@ -1,0 +1,102 @@
+package com.smore.seller.infrastructure.kafka.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.seller.application.port.in.InboxService;
+import com.smore.seller.application.usecase.CreditSellerMoney;
+import com.smore.seller.infrastructure.kafka.SellerTopicProperties;
+import com.smore.seller.infrastructure.kafka.listener.dto.SettlementFailedV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "spring.kafka.bootstrap-servers")
+@RequiredArgsConstructor
+public class SellerKafkaListener {
+
+    private final ObjectMapper objectMapper;
+    private final CreditSellerMoney creditSellerMoney;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final SellerTopicProperties topic;
+    private final InboxService inboxService;
+
+    @KafkaListener(
+        topics = "payment.settlement-failed.v1"
+    )
+
+    // 회원이 정산 요청을 보냈지만 정산이 실패한 경우 돈+
+    public void paymentSettlementFailedV1(String event, Acknowledgment ack) {
+        log.info("Received event {}", event);
+        try {
+            var paymentSettlementFailed
+                = objectMapper.readValue(event, SettlementFailedV1.class);
+
+            log.info("AuctionStartedV1 deserialize {}", paymentSettlementFailed);
+
+            inboxService.processOnce(
+                paymentSettlementFailed.idempotencyKey(),
+                () -> creditSellerMoney.credit(
+                    paymentSettlementFailed.id(),
+                    paymentSettlementFailed.amount()
+                )
+            );
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("PaymentSettlementFailedV1 - error: {}", e.getMessage());
+            kafkaTemplate.send(
+                topic.getSellerDeadLetter().get("v1"),
+                event
+            );
+            ack.acknowledge();
+        }
+    }
+
+    // 결제성공하여 seller 지갑에 돈+
+    @KafkaListener(
+        topics = "payment.settlement.v1"
+    )
+    public void paymentSettlementV1(String event, Acknowledgment ack) {
+        log.info("Received event {}", event);
+
+        try {
+            var settlement
+                = objectMapper.readValue(event, SettlementFailedV1.class);
+
+            log.info("AuctionStartedV1 deserialize {}", settlement);
+
+            // 멱등검사
+            inboxService.processOnce(
+                settlement.idempotencyKey(),
+                () -> creditSellerMoney.credit(
+                    settlement.id(),
+                    settlement.amount()
+                )
+            );
+
+            // 메서드 내부에서 재시도로직 존재
+            creditSellerMoney.credit(settlement.id(), settlement.amount());
+
+            ack.acknowledge();
+
+        } catch (JsonProcessingException | RuntimeException e) {
+            log.error("PaymentSettlementFailedV1 - error: {}", e.getMessage());
+            // 수복 불가능한 예외는 DLT 로 던짐
+            kafkaTemplate.send(
+                topic.getSellerDeadLetter().get("v1"),
+                event
+            );
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("예외 발생: {}", e.getMessage());
+            // 리트라이등의 처리는 추후 DefaultErrorHandler 를 추가하여 전역처리 예정입니다
+            ack.acknowledge();
+        }
+    }
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/SellerKafkaListener.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/SellerKafkaListener.java
@@ -6,6 +6,7 @@ import com.smore.seller.application.port.in.InboxService;
 import com.smore.seller.application.usecase.CreditSellerMoney;
 import com.smore.seller.infrastructure.kafka.SellerTopicProperties;
 import com.smore.seller.infrastructure.kafka.listener.dto.SettlementFailedV1;
+import com.smore.seller.infrastructure.kafka.listener.dto.SettlementV1;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -67,7 +68,7 @@ public class SellerKafkaListener {
 
         try {
             var settlement
-                = objectMapper.readValue(event, SettlementFailedV1.class);
+                = objectMapper.readValue(event, SettlementV1.class);
 
             log.info("AuctionStartedV1 deserialize {}", settlement);
 
@@ -79,9 +80,6 @@ public class SellerKafkaListener {
                     settlement.amount()
                 )
             );
-
-            // 메서드 내부에서 재시도로직 존재
-            creditSellerMoney.credit(settlement.id(), settlement.amount());
 
             ack.acknowledge();
 

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/dto/SettlementFailedV1.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/dto/SettlementFailedV1.java
@@ -1,0 +1,15 @@
+package com.smore.seller.infrastructure.kafka.listener.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SettlementFailedV1(
+    Long id,
+    BigDecimal amount,
+    String accountNum,
+    String failedReason,
+    UUID idempotencyKey,
+    LocalDateTime createdAt
+) {
+}

--- a/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/dto/SettlementV1.java
+++ b/member/src/main/java/com/smore/seller/infrastructure/kafka/listener/dto/SettlementV1.java
@@ -1,0 +1,12 @@
+package com.smore.seller.infrastructure.kafka.listener.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record SettlementV1(
+    Long id,
+    BigDecimal amount,
+    UUID idempotencyKey
+) {
+
+}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -26,7 +26,7 @@ seller:
       v2: seller.register.v2
     seller-settlement:
       v1: seller.settlement.v1
-    seller-deadLetter:
+    seller-dead-letter:
       v1: seller.deadLetter.v1
 
 member:

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -26,6 +26,8 @@ seller:
       v2: seller.register.v2
     seller-settlement:
       v1: seller.settlement.v1
+    seller-deadLetter:
+      v1: seller.deadLetter.v1
 
 member:
   topic:

--- a/member/src/test/java/com/smore/seller/infrastructure/kafka/listener/SellerKafkaListenerTest.java
+++ b/member/src/test/java/com/smore/seller/infrastructure/kafka/listener/SellerKafkaListenerTest.java
@@ -1,0 +1,127 @@
+package com.smore.seller.infrastructure.kafka.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smore.seller.application.port.in.InboxService;
+import com.smore.seller.application.usecase.CreditSellerMoney;
+import com.smore.seller.infrastructure.kafka.SellerTopicProperties;
+import com.smore.seller.infrastructure.kafka.listener.dto.SettlementV1;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class SellerKafkaListenerTest {
+
+    private static final String DEAD_LETTER_TOPIC = "seller.deadletter.v1";
+
+    @Mock
+    private CreditSellerMoney creditSellerMoney;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private InboxService inboxService;
+
+    @Mock
+    private Acknowledgment ack;
+
+    private ObjectMapper objectMapper;
+    private SellerKafkaListener listener;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        SellerTopicProperties topic = new SellerTopicProperties();
+        topic.setSellerDeadLetter(Map.of("v1", DEAD_LETTER_TOPIC));
+
+        listener = new SellerKafkaListener(
+            objectMapper,
+            creditSellerMoney,
+            kafkaTemplate,
+            topic,
+            inboxService
+        );
+    }
+
+    @Test
+    @DisplayName("정상흐름 function 이 1번 호출, ack 호출, DLT 발행 X")
+    void paymentSettlementV1_processesOnceAndAcknowledges() throws Exception {
+        SettlementV1 event = new SettlementV1(
+            1L,
+            new BigDecimal("123.45"),
+            UUID.randomUUID()
+        );
+        String payload = objectMapper.writeValueAsString(event);
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(1);
+            runnable.run();
+            return null;
+        }).when(inboxService).processOnce(eq(event.idempotencyKey()), any());
+
+        listener.paymentSettlementV1(payload, ack);
+
+        verify(inboxService).processOnce(eq(event.idempotencyKey()), any());
+        verify(creditSellerMoney).credit(event.id(), event.amount());
+        verify(kafkaTemplate, never()).send(anyString(), anyString());
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    @DisplayName("멱등키가 같은 이벤트를 listen 하였을때, processOnce 는 두 번 호출, function 은 1번 호출")
+    void paymentSettlementV1_isIdempotentForSameIdempotencyKey() throws Exception {
+        SettlementV1 event = new SettlementV1(
+            7L,
+            new BigDecimal("5.00"),
+            UUID.randomUUID()
+        );
+        String payload = objectMapper.writeValueAsString(event);
+        AtomicInteger processCallCount = new AtomicInteger();
+
+        doAnswer(invocation -> {
+            if (processCallCount.getAndIncrement() == 0) {
+                invocation.<Runnable>getArgument(1).run();
+            }
+            return null;
+        }).when(inboxService).processOnce(eq(event.idempotencyKey()), any());
+
+        listener.paymentSettlementV1(payload, ack);
+        listener.paymentSettlementV1(payload, ack);
+
+        verify(inboxService, times(2)).processOnce(eq(event.idempotencyKey()), any());
+        verify(creditSellerMoney, times(1)).credit(event.id(), event.amount());
+        verify(kafkaTemplate, never()).send(anyString(), anyString());
+        verify(ack, times(2)).acknowledge();
+    }
+
+    @Test
+    @DisplayName("역직렬화 예외 발생시 DLT 전송 및 ack 호출")
+    void paymentSettlementFailedV1_sendsToDeadLetterOnDeserializationError() {
+        String invalidPayload = "{invalid json";
+
+        listener.paymentSettlementFailedV1(invalidPayload, ack);
+
+        verifyNoInteractions(inboxService, creditSellerMoney);
+        verify(kafkaTemplate).send(DEAD_LETTER_TOPIC, invalidPayload);
+        verify(ack).acknowledge();
+    }
+}


### PR DESCRIPTION
## Spring retry 를 사용하여 재시도 설정
b76fee8bee5d42ef15611cc3bb127da1e3bc39fb
### CreditSellerMoneyImpl
- 재시도 할 예외와 재시도 하지 않는 예외 설정
- maxDelay 설정하여 최대 딜레이 시간 설정

### InboxServiceImpl
- 인박스 패턴으로 성공한 이벤트는 멱등키를 인박스 테이블에 저장
- 성공한 이벤트는 동일 이벤트로 중복처리 되지 않게 구성

### SellerKafkaListener
- 수복 불가능한 예외는 DLT 로 던진후 ack 처리
- 수복 가능한 예외는 이후 DefaultErrorHandler 를 통해서 Listener 코드에 try catch 블록을 없애고 공통처리 할때 재시도 관련해서 추가할 예정입니다

## 코드의 각종 오류 사항 수정
4c25eb4233350c4fd99008354f071974874e8731
- credit 을 두 번 호출하던 문제수정
- sellerInbox 의 멱등키에 유니크 설정 추가

## 이후 개선 부분
- DefaultErrorHandler 를 통한 카프카 리스너 예외 공통처리
- credit 비즈니스 로직중 동시성 제어를 위한 락 추가
- InboxService 내부 코드를 upsert 또는 insert 후 시도등을 통해서 멱등처리 강화
