### PR TITLE
refactor: auction/calculate

### DIFF
--- a/auction/src/main/java/com/smore/auction/application/usecase/impl/AuctionBidCalculatorImpl.java
+++ b/auction/src/main/java/com/smore/auction/application/usecase/impl/AuctionBidCalculatorImpl.java
@@ -25,9 +25,7 @@ public class AuctionBidCalculatorImpl implements AuctionBidCalculator {
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
-    // TODO: 한 경매에 관해서 입찰한 내역이 중복으로 계속 들어가는 상황 발생
-    // zset -> userId, score 로 관리
-    // hset -> userId, metaData 로 관리 예정
+    // TODO: 한 경매에 관해서 입찰한 내역이 중복으로 계속 들어가는 상황 발생 -> 이렇게 해서 다중수량을 구매하게 가능 quantity 필드는 삭제
     // hset -> auctionId -> auction meta 로 기본시작 경매금 및 minStep 등 관리
     @Override
     public AuctionBidCalculateResult calculateBid(BigDecimal bidPrice, Integer quantity, String auctionId, String userId) {

--- a/auction/src/main/java/com/smore/auction/application/usecase/impl/AuctionStartImpl.java
+++ b/auction/src/main/java/com/smore/auction/application/usecase/impl/AuctionStartImpl.java
@@ -20,6 +20,7 @@ public class AuctionStartImpl implements AuctionStart {
     private final AuctionRoomRegistry roomRegistry;
 
     // 경매시작 비즈니스 로직
+    // TODO: 경매 시작시 stock(불변) 값을 가진 auction:{auctionId}:open:stock 키 생성해서 값으로 stock 저장
     @Override
     public void start(AuctionStartCommand command){
 

--- a/auction/src/main/java/com/smore/auction/application/usecase/impl/ConfirmAuctionBidImpl.java
+++ b/auction/src/main/java/com/smore/auction/application/usecase/impl/ConfirmAuctionBidImpl.java
@@ -8,6 +8,7 @@ import com.smore.auction.domain.events.AuctionWinnerConfirmV1;
 import com.smore.auction.domain.model.Auction;
 import com.smore.auction.domain.model.AuctionBidderRank;
 import jakarta.transaction.Transactional;
+import java.time.Clock;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -25,6 +26,7 @@ public class ConfirmAuctionBidImpl implements ConfirmAuctionBid {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final AuctionSqlRepository repository;
     private final ObjectMapper objectMapper;
+    private final Clock clock;
 
     @SneakyThrows
     @Override
@@ -45,7 +47,8 @@ public class ConfirmAuctionBidImpl implements ConfirmAuctionBid {
                 auctionBidderRank.getBidder().quantity(),
                 auction.getProduct().categoryId(),
                 auction.getSellerId(),
-                UUID.randomUUID()
+                UUID.randomUUID(),
+                clock
             );
 
         var future = kafkaTemplate.send(

--- a/auction/src/main/java/com/smore/auction/domain/events/AuctionWinnerConfirmV1.java
+++ b/auction/src/main/java/com/smore/auction/domain/events/AuctionWinnerConfirmV1.java
@@ -1,6 +1,7 @@
 package com.smore.auction.domain.events;
 
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -29,7 +30,8 @@ public class AuctionWinnerConfirmV1 {
         Integer quantity,
         UUID categoryId,
         Long sellerId,
-        UUID idempotencyKey
+        UUID idempotencyKey,
+        Clock clock
     ) {
         return new AuctionWinnerConfirmV1(
             userId,
@@ -40,10 +42,10 @@ public class AuctionWinnerConfirmV1 {
             "AUCTION",
             sellerId,
             idempotencyKey,
-            null,
-            null,
-            null,
-            null
+            LocalDateTime.now().plusMinutes(5),
+            "입력 필요",
+            "입력 필요",
+            "입력 필요"
         );
     }
 }

--- a/auction/src/main/java/com/smore/auction/presentation/websocket/AuctionStompController.java
+++ b/auction/src/main/java/com/smore/auction/presentation/websocket/AuctionStompController.java
@@ -4,12 +4,14 @@ import com.smore.auction.application.usecase.AuctionBidCalculator;
 import com.smore.auction.presentation.websocket.dto.request.AuctionBidRequestDto;
 import com.smore.auction.presentation.websocket.dto.response.AuctionBidResponseDto;
 import com.smore.auction.presentation.websocket.mapper.AuctionWebSocketMapper;
+import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
@@ -27,7 +29,7 @@ public class AuctionStompController {
     public void handleBid(
         @DestinationVariable UUID auctionId,
         Principal principal,
-        AuctionBidRequestDto auctionBidRequestDto
+        @Payload @Valid AuctionBidRequestDto auctionBidRequestDto
     ) {
         log.info("Received a bid request for {}", auctionId);
         log.info("Received a bid request for {}", auctionBidRequestDto);

--- a/auction/src/main/java/com/smore/auction/presentation/websocket/dto/request/AuctionBidRequestDto.java
+++ b/auction/src/main/java/com/smore/auction/presentation/websocket/dto/request/AuctionBidRequestDto.java
@@ -1,9 +1,16 @@
 package com.smore.auction.presentation.websocket.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 public record AuctionBidRequestDto(
+    @NotNull
     BigDecimal bidPrice,
+    @NotNull
+    @Max(1)
+    @Min(1)
     Integer quantity
 ) {
 


### PR DESCRIPTION
## 다중 수량구매 방향성 정리
887bf052736096f9bbaf74eaafa77056cfb31170
- 한 명의 유저가 중복입찰 가능하게 하고 수량을 1개로 한정하여
- 각각이 독립적인 입찰로 다중 수량 구매 가능하게 변경
- 이후 입찰 최솟값을 stock 순위에 있는 의미있는 입찰가 미만으로 할 수 없게 변경 예정 (의미없는 입찰을 막기 위함)