### PR TITLE
Order : 경매 주문 진입 경로 연결

### DIFF
--- a/order/src/main/java/com/smore/order/application/command/AuctionOrderFailedHandler.java
+++ b/order/src/main/java/com/smore/order/application/command/AuctionOrderFailedHandler.java
@@ -1,0 +1,42 @@
+package com.smore.order.application.command;
+
+import com.smore.order.domain.model.Outbox;
+import com.smore.order.domain.status.OutboxResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Slf4j(topic = "AuctionOrderFailedHandler")
+public class AuctionOrderFailedHandler implements OutboxHandler {
+
+    private final String topic;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Outbox outbox;
+
+    public AuctionOrderFailedHandler(String topic, KafkaTemplate<String, String> kafkaTemplate, Outbox outbox) {
+        this.topic = topic;
+        this.kafkaTemplate = kafkaTemplate;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public OutboxResult execute() {
+        log.info("AuctionOrderFailed 이벤트 발행 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+            outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+        try {
+            kafkaTemplate.send(topic, outbox.getPayload())
+                .get();
+
+            log.info("AuctionOrderFailed 이벤트 발행 성공 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+                outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+            return OutboxResult.SUCCESS;
+        } catch (Exception e) {
+
+            log.error("AuctionOrderFailed 이벤트 발행 실패 - 도메인 : {}, 이벤트 : {}, orderId : {}, ",
+                outbox.getAggregateType(), outbox.getEventType(), outbox.getAggregateId());
+
+            return OutboxResult.FAIL;
+        }
+    }
+}

--- a/order/src/main/java/com/smore/order/application/event/inbound/AuctionWinnerConfirmedEvent.java
+++ b/order/src/main/java/com/smore/order/application/event/inbound/AuctionWinnerConfirmedEvent.java
@@ -1,0 +1,27 @@
+package com.smore.order.application.event.inbound;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AuctionWinnerConfirmedEvent {
+
+    private Long userId;
+    private UUID productId;
+    private Integer productPrice;
+    private Integer quantity;
+    private UUID categoryId;
+    private String saleType;
+    private Long sellerId;
+    private UUID idempotencyKey;
+    private LocalDateTime expiresAt;
+    private String street;
+    private String city;
+    private String zipcode;
+
+}

--- a/order/src/main/java/com/smore/order/application/event/outbound/AuctionOrderFailedEvent.java
+++ b/order/src/main/java/com/smore/order/application/event/outbound/AuctionOrderFailedEvent.java
@@ -1,0 +1,24 @@
+package com.smore.order.application.event.outbound;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuctionOrderFailedEvent implements OrderEvent {
+    private UUID productId;
+    private Long userId;
+    private UUID idempotencyKey;
+
+    public static AuctionOrderFailedEvent of(UUID productId, Long userId, UUID idempotencyKey) {
+        return AuctionOrderFailedEvent.builder()
+            .productId(productId)
+            .userId(userId)
+            .idempotencyKey(idempotencyKey)
+            .build();
+    }
+}

--- a/order/src/main/java/com/smore/order/application/factory/OutboxHandlerFactory.java
+++ b/order/src/main/java/com/smore/order/application/factory/OutboxHandlerFactory.java
@@ -1,5 +1,6 @@
 package com.smore.order.application.factory;
 
+import com.smore.order.application.command.AuctionOrderFailedHandler;
 import com.smore.order.application.command.CompletedOrderHandler;
 import com.smore.order.application.command.CreatedOrderHandler;
 import com.smore.order.application.command.FailedOrderHandler;
@@ -38,6 +39,9 @@ public class OutboxHandlerFactory {
     @Value("${topic.order.failed}")
     private String orderFailedTopic;
 
+    @Value("${topic.order.auction-failed}")
+    private String auctionOrderFailedTopic;
+
     public OutboxHandler from(Outbox outbox) {
         return switch (outbox.getEventType()) {
             case ORDER_CREATED -> new CreatedOrderHandler(orderCreatedTopic, kafkaTemplate, outbox);
@@ -45,7 +49,8 @@ public class OutboxHandlerFactory {
             case REFUND_REQUEST -> new RefundRequestHandler(refundRequestTopic, kafkaTemplate, outbox);
             case REFUND_SUCCESS -> new RefundSuccessHandler(refundSuccessTopic, kafkaTemplate, outbox);
             case REFUND_FAIL -> new RefundFailedHandler(refundFailTopic, kafkaTemplate, outbox);
-            case ORDER_FAILED -> new FailedOrderHandler(orderFailedTopic, kafkaTemplate, outbox);
+            case BID_ORDER_FAILED -> new FailedOrderHandler(orderFailedTopic, kafkaTemplate, outbox);
+            case AUCTION_ORDER_FAILED -> new AuctionOrderFailedHandler(auctionOrderFailedTopic, kafkaTemplate, outbox);
             default -> throw new IllegalArgumentException(
                 "지원되지 않은 이벤트입니다." + outbox.getEventType()
             );

--- a/order/src/main/java/com/smore/order/application/service/OrderService.java
+++ b/order/src/main/java/com/smore/order/application/service/OrderService.java
@@ -9,6 +9,7 @@ import com.smore.order.application.dto.FailedOrderCommand;
 import com.smore.order.application.dto.FailedRefundCommand;
 import com.smore.order.application.dto.ModifyOrderCommand;
 import com.smore.order.application.dto.RefundCommand;
+import com.smore.order.application.event.outbound.AuctionOrderFailedEvent;
 import com.smore.order.application.event.outbound.OrderFailedEvent;
 import com.smore.order.application.exception.OrderIdMisMatchException;
 import com.smore.order.application.exception.RefundReservationConflictException;
@@ -135,6 +136,10 @@ public class OrderService {
         if (updated == 0) {
             log.error("주문 완료 상태로 변경하지 못했습니다. orderId = {}, methodName = {}", orderId, "completeOrder");
             throw new CompleteOrderFailException(OrderErrorCode.COMPLETE_ORDER_CONFLICT);
+        }
+
+        if (order.isAuction()) {
+            return ServiceResult.SUCCESS;
         }
 
         OrderCompletedEvent event = OrderCompletedEvent.of(
@@ -549,7 +554,7 @@ public class OrderService {
             throw new UpdateOrderFailException(OrderErrorCode.UPDATE_ORDER_FAIL_CONFLICT);
         }
 
-        OrderFailedEvent event = OrderFailedEvent.of(
+        OrderEvent event = OrderFailedEvent.of(
             order.getIdempotencyKey(),
             order.getProduct().productId(),
             order.getUserId(),
@@ -557,10 +562,22 @@ public class OrderService {
             LocalDateTime.now(clock)
         );
 
+        EventType eventType = EventType.BID_ORDER_FAILED;
+
+        if (order.isAuction()) {
+            event = AuctionOrderFailedEvent.of(
+                order.getProduct().productId(),
+                order.getUserId(),
+                order.getIdempotencyKey()
+            );
+
+            eventType = EventType.AUCTION_ORDER_FAILED;
+        }
+
         Outbox outbox = Outbox.create(
             AggregateType.ORDER,
             order.getId(),
-            EventType.ORDER_FAILED,
+            eventType,
             UUID.randomUUID(),
             makePayload(event)
         );

--- a/order/src/main/java/com/smore/order/domain/model/Order.java
+++ b/order/src/main/java/com/smore/order/domain/model/Order.java
@@ -188,6 +188,10 @@ public class Order {
     public boolean isFailed() {
         return this.orderStatus == OrderStatus.FAILED;
     }
+
+    public boolean isAuction() {
+        return this.saleType == SaleType.AUCTION;
+    }
   
     private static Integer calculateTotalPrice(Integer price, Integer quantity) {
         return price * quantity;

--- a/order/src/main/java/com/smore/order/domain/status/EventType.java
+++ b/order/src/main/java/com/smore/order/domain/status/EventType.java
@@ -3,7 +3,8 @@ package com.smore.order.domain.status;
 public enum EventType {
     ORDER_CREATED("주문 생성 완료"),
     ORDER_COMPLETED("주문 완료"),
-    ORDER_FAILED("주문 실패"),
+    BID_ORDER_FAILED("경쟁 주문 실패"),
+    AUCTION_ORDER_FAILED("경매 주문 실패"),
     REFUND_REQUEST("환불 요청"),
     REFUND_SUCCESS("환불 성공"),
     REFUND_FAIL("환불 실패"),

--- a/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
+++ b/order/src/main/java/com/smore/order/infrastructure/config/KafkaConfig.java
@@ -27,6 +27,9 @@ public class KafkaConfig {
     @Value("${topic.order.failed}")
     private String orderFailedTopic;
 
+    @Value("${topic.order.auction-failed}")
+    private String auctionOrderFailedTopic;
+
     @Bean
     public NewTopic orderCreatedTopic() {
         return TopicBuilder.name(createdOrderTopic)
@@ -70,6 +73,14 @@ public class KafkaConfig {
     @Bean
     public NewTopic orderFailedTopic() {
         return TopicBuilder.name(orderFailedTopic)
+            .partitions(3)
+            .replicas(3)
+            .build();
+    }
+
+    @Bean
+    public NewTopic auctionOrderFailedTopic() {
+        return TopicBuilder.name(auctionOrderFailedTopic)
             .partitions(3)
             .replicas(3)
             .build();

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -40,6 +40,7 @@ topic:
     refund-success: order.refund-success.v1
     refund-fail: order.refund-fail.v1
     failed: order.failed.v1
+    auction-failed: order.auctionfailed.v1
 
   bid:
     order:

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -49,7 +49,7 @@ topic:
 
   auction:
     order:
-      request: acution.winnerconfirm.v1
+      request: auction.winnerConfirm.v1
 
   payment:
     completed: payment.approved.v1
@@ -61,6 +61,7 @@ consumer:
   group:
     payment: payment-consumer-group
     bid: bid-consumer-group
+    auction: auction-consumer-group
 
 retry:
   count:


### PR DESCRIPTION
### 요약
- `auction.winnerConfirm.v1 `토픽 리스너 추가/수정으로 경매 낙찰 -> 주문 생성 흐름 연결 
- 경매 주문 완료 이벤트는 발행하지 않고, 결제 실패 시 `order.auctionfailed.v1`으로 발행하도록 분기
