### PR TITLE
Feat: 상품 검색을 위한 Elasticsearch 기반 검색 엔진 도입

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,15 @@
     networks:
       - msa-network
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: smore-es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+
 
   redisinsight:
     image: redis/redisinsight:latest

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     // MSK 설치
     implementation 'software.amazon.msk:aws-msk-iam-auth:2.2.0'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/product/src/main/java/com/smore/product/application/service/ProductSearchService.java
+++ b/product/src/main/java/com/smore/product/application/service/ProductSearchService.java
@@ -1,0 +1,20 @@
+package com.smore.product.application.service;
+
+import com.smore.product.infrastructure.search.document.ProductDocument;
+import com.smore.product.infrastructure.search.repository.ProductSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductSearchService {
+
+    private final ProductSearchRepository productSearchRepository;
+
+    public List<ProductDocument> search(String keyword) {
+        return productSearchRepository
+                .findByNameContainingOrDescriptionContaining(keyword, keyword);
+    }
+}

--- a/product/src/main/java/com/smore/product/infrastructure/search/config/ElasticsearchConfig.java
+++ b/product/src/main/java/com/smore/product/infrastructure/search/config/ElasticsearchConfig.java
@@ -1,0 +1,11 @@
+package com.smore.product.infrastructure.search.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(
+        basePackages = "com.smore.product.infrastructure.search.repository"
+)
+public class ElasticsearchConfig {
+}

--- a/product/src/main/java/com/smore/product/infrastructure/search/document/ProductDocument.java
+++ b/product/src/main/java/com/smore/product/infrastructure/search/document/ProductDocument.java
@@ -1,13 +1,17 @@
 package com.smore.product.infrastructure.search.document;
 
+import com.smore.product.domain.entity.Product;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Document(indexName = "products")
 @Getter
@@ -19,8 +23,37 @@ public class ProductDocument {
     @Id
     private String id;
 
+    private String categoryId;
+
     private String name;
     private String description;
-    private String categoryId;
+
     private BigDecimal price;
+
+    private String saleType;
+    private String status;
+
+    @Field(type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @Field(type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startAt;
+
+    @Field(type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endAt;
+
+    public static ProductDocument from(Product product) {
+        return ProductDocument.builder()
+                .id(product.getId().toString())
+                .categoryId(product.getCategoryId().toString())
+                .name(product.getName())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .saleType(product.getSaleType().name())
+                .status(product.getStatus().name())
+                .createdAt(product.getCreatedAt())
+                .startAt(product.getStartAt())
+                .endAt(product.getEndAt())
+                .build();
+    }
 }

--- a/product/src/main/java/com/smore/product/infrastructure/search/document/ProductDocument.java
+++ b/product/src/main/java/com/smore/product/infrastructure/search/document/ProductDocument.java
@@ -1,0 +1,26 @@
+package com.smore.product.infrastructure.search.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import java.math.BigDecimal;
+
+@Document(indexName = "products")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductDocument {
+
+    @Id
+    private String id;
+
+    private String name;
+    private String description;
+    private String categoryId;
+    private BigDecimal price;
+}

--- a/product/src/main/java/com/smore/product/infrastructure/search/repository/ProductSearchRepository.java
+++ b/product/src/main/java/com/smore/product/infrastructure/search/repository/ProductSearchRepository.java
@@ -3,6 +3,20 @@ package com.smore.product.infrastructure.search.repository;
 import com.smore.product.infrastructure.search.document.ProductDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.List;
+
 public interface ProductSearchRepository
         extends ElasticsearchRepository<ProductDocument, String> {
+
+    // 키워드 검색 (name + description)
+    List<ProductDocument> findByNameContainingOrDescriptionContaining(
+            String name,
+            String description
+    );
+
+    // 카테고리 + 상태 필터
+    List<ProductDocument> findByCategoryIdAndStatus(
+            String categoryId,
+            String status
+    );
 }

--- a/product/src/main/java/com/smore/product/infrastructure/search/repository/ProductSearchRepository.java
+++ b/product/src/main/java/com/smore/product/infrastructure/search/repository/ProductSearchRepository.java
@@ -1,0 +1,8 @@
+package com.smore.product.infrastructure.search.repository;
+
+import com.smore.product.infrastructure.search.document.ProductDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ProductSearchRepository
+        extends ElasticsearchRepository<ProductDocument, String> {
+}

--- a/product/src/main/java/com/smore/product/presentation/controller/ElasticsearchTestController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ElasticsearchTestController.java
@@ -1,0 +1,21 @@
+package com.smore.product.presentation.controller;
+
+import com.smore.product.infrastructure.search.repository.ProductSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/es-test")
+@RequiredArgsConstructor
+public class ElasticsearchTestController {
+
+    private final ProductSearchRepository productSearchRepository;
+
+    @GetMapping("/ping")
+    public String ping() {
+        productSearchRepository.count(); // ES에 실제 요청
+        return "ES CONNECTED";
+    }
+}

--- a/product/src/main/java/com/smore/product/presentation/controller/ProductSearchController.java
+++ b/product/src/main/java/com/smore/product/presentation/controller/ProductSearchController.java
@@ -1,0 +1,30 @@
+package com.smore.product.presentation.controller;
+
+import com.smore.common.response.ApiResponse;
+import com.smore.common.response.CommonResponse;
+import com.smore.product.application.service.ProductSearchService;
+import com.smore.product.infrastructure.search.document.ProductDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products/search")
+public class ProductSearchController {
+
+    private final ProductSearchService productSearchService;
+
+    @GetMapping
+    public CommonResponse<List<ProductDocument>> search(
+            @RequestParam String keyword
+    ) {
+        return ApiResponse.ok(
+                productSearchService.search(keyword)
+        );
+    }
+}

--- a/product/src/main/resources/application-local.yml
+++ b/product/src/main/resources/application-local.yml
@@ -3,6 +3,9 @@ spring:
     activate:
       on-profile: local
 
+  elasticsearch:
+    uris: http://localhost:9200
+
   datasource:
     url: jdbc:postgresql://localhost:5432/product
     username: root


### PR DESCRIPTION
## 개요
기존 DB 기반 상품 조회 구조에서 벗어나,
Elasticsearch를 상품 검색 전용 엔진으로 도입했습니다.
상품 검색 성능 개선과 향후 ETL·대규모 데이터·벡터 검색 확장을 위한 기반 작업입니다.

## 주요 변경 사항
- Elasticsearch 의존성 및 로컬/도커 설정 추가
- 상품 검색 전용 ES 문서 모델(ProductDocument) 정의
- Spring ↔ Elasticsearch 연결 및 헬스 체크 테스트 구성
- ElasticsearchRepository 기반 상품 검색 레포지토리 구현
- 상품 검색 서비스/컨트롤러 분리
- 상품 생성·상태 변경·삭제 시 ES 색인 동기화 처리

## 설계 포인트
- 검색 전용 모델 분리
- DB 엔티티와 검색 모델(ProductDocument)을 분리하여 책임 분리
- 검색 API 분리
- 상품 조회 API와 검색 API를 분리하여 확장성 확보
- 색인 동기화
- 상품 생명주기(Create / Update / Delete)에 맞춰 ES 문서 동기화

## 테스트 방법
1. 상품 생성 API 호출
→ ES 인덱스에 문서 생성 확인
2. /api/v1/products/search?keyword=상품 호출
→ Elasticsearch 기반 검색 결과 반환 확인
3. ES 직접 조회
GET http://localhost:9200/products/_search