### PR TITLE
Feat(Bid) : 선착순 시스템 부하 분산 구현 

### DIFF
--- a/bidcompetition/build.gradle
+++ b/bidcompetition/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // MSK 설치
+    implementation 'software.amazon.msk:aws-msk-iam-auth:2.2.0'
 }
 
 dependencyManagement {

--- a/bidcompetition/build.gradle
+++ b/bidcompetition/build.gradle
@@ -69,6 +69,9 @@ dependencies {
 
     // prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/WinnerRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/WinnerRepository.java
@@ -12,7 +12,7 @@ public interface WinnerRepository {
 
     Winner findById(UUID winnerId);
 
-    Winner findByIdempotencyKey(UUID idempotencyKey);
+    Winner findByIdempotencyKey(UUID bidId, UUID idempotencyKey);
 
     Winner findByAllocationKey(UUID allocationKey);
 

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
@@ -27,8 +27,11 @@ import com.smore.bidcompetition.infrastructure.persistence.event.outbound.BidEve
 import com.smore.bidcompetition.infrastructure.persistence.event.outbound.BidProductInventoryAdjustedEvent;
 import com.smore.bidcompetition.infrastructure.persistence.event.outbound.InventoryConfirmationTimeOutEvent;
 import com.smore.bidcompetition.infrastructure.persistence.event.outbound.WinnerCreatedEvent;
+import com.smore.bidcompetition.infrastructure.redis.StockRedisService;
 import com.smore.bidcompetition.presentation.dto.BidResponse;
+import io.lettuce.core.RedisCommandTimeoutException;
 import io.micrometer.tracing.Tracer;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -36,6 +39,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BidCompetitionService {
 
+    private final RedisTemplate<Object, Object> redisTemplate;
     @Value("${app.allocation.valid-duration}")
     private long validDurationSeconds;
 
@@ -54,6 +59,7 @@ public class BidCompetitionService {
     private final WinnerRepository winnerRepository;
     private final OutboxRepository outboxRepository;
     private final BidInventoryLogRepository bidInventoryLogRepository;
+    private final StockRedisService stockRedisService;
     private final Tracer tracer;
     private final ObjectMapper objectMapper;
     private final Clock clock;
@@ -81,143 +87,250 @@ public class BidCompetitionService {
             command.getEndAt()
         );
 
-        bidCompetitionRepository.save(newBid);
+        BidCompetition saved = bidCompetitionRepository.save(newBid);
+
+        try {
+            long setResult = stockRedisService.setStock(saved.getId(), saved.getTotalQuantity());
+
+            if (setResult == -1L) {
+                log.error("재고 초기화 실패: bidId={}, stock={}", saved.getId(), saved.getTotalQuantity());
+            } else if (setResult == 0L) {
+                log.info("이미 재고 키가 존재합니다. bidId={}", saved.getId());
+            } else {
+                log.info("재고 초기화 완료: bidId={}, stock={}", saved.getId(), setResult);
+            }
+        } catch (Exception e) {
+            log.error("재고 초기화 중 예외 발생. bidId={}", saved.getId(), e);
+        }
     }
 
     @Transactional
     public BidResponse competition(CompetitionCommand command) {
 
         LocalDateTime now = LocalDateTime.now(clock);
-
-        Winner winner = winnerRepository.findByIdempotencyKey(command.getIdempotencyKey());
-
-        if (winner != null) {
-            log.info("이미 처리된 작업입니다. userId : {}, bidId : {} idempotencyKey : {}",
-                command.getUserId(), command.getBidId(), command.getIdempotencyKey());
-            return BidResponse.success(
-                winner.getBidId(),
-                winner.getProductId(),
-                winner.getQuantity(),
-                winner.getAllocationKey(),
-                winner.getExpireAt()
-            );
-        }
-
-        // 비관락
-        BidCompetition bid = bidCompetitionRepository.findByIdForUpdate(command.getBidId());
-
         LocalDateTime expireAt = now.plusSeconds(validDurationSeconds);
+        UUID allocationKey = UUID.nameUUIDFromBytes(
+            ("ALLOC:" + command.getBidId() + ":" + command.getIdempotencyKey()).getBytes(StandardCharsets.UTF_8)
+        );
 
-        // 경쟁 상태 점검
-        if (bid.isNotActive() || bid.isExpired(now)) {
-            log.info("판매 경쟁이 종료되었습니다.");
+        long keyTtl = validDurationSeconds + bufferTimeSeconds + 120L;
+
+        try {
+            long reserveResult = stockRedisService.reserve(
+                command.getBidId(),
+                allocationKey.toString(),
+                command.getIdempotencyKey().toString(),
+                command.getUserId().toString(),
+                command.getQuantity(),
+                keyTtl
+            );
+
+            // 처리중이거나 이미 처리된 작업
+            if (reserveResult == -2L) {
+
+                Winner winner = winnerRepository.findByIdempotencyKey(command.getBidId(), command.getIdempotencyKey());
+
+                if (winner != null) {
+                    return BidResponse.success(
+                        winner.getBidId(),
+                        winner.getQuantity(),
+                        winner.getAllocationKey(),
+                        winner.getExpireAt()
+                    );
+                }
+
+                return BidResponse.processing(
+                    command.getBidId(),
+                    command.getQuantity(),
+                    allocationKey,
+                    "처리중/중복 요청"
+                );
+            }
+
+            if (reserveResult != 1L) {
+                return BidResponse.fail(
+                    command.getBidId(),
+                    command.getQuantity(),
+                    "재고 부족 또는 확보 실패"
+                );
+            }
+        } catch (RedisCommandTimeoutException e) {
+            return BidResponse.processing(
+                command.getBidId(),
+                command.getQuantity(),
+                allocationKey,
+                "일시적 네트워크 오류. 재시도해주세요."
+            );
+        } catch (Exception e) {
+            log.error("reserve 단계 예외", e);
+
+            stockRedisService.rollback(
+                command.getBidId(),
+                allocationKey.toString(),
+                command.getIdempotencyKey().toString(),
+                command.getQuantity()
+            );
+
             return BidResponse.fail(
                 command.getBidId(),
-                bid.getProductId(),
                 command.getQuantity(),
-                "판매 경쟁이 종료되어 주문을 받을 수 없습니다."
+                "예기치 못한 예외 발생"
             );
         }
 
-        // 재고 확인 및 확보
-        int updated = bidCompetitionRepository.decreaseStock(
-            command.getBidId(),
-            command.getQuantity(),
-            now
-        );
+        try {
+            Winner winner = winnerRepository.findByIdempotencyKey(command.getBidId(), command.getIdempotencyKey());
 
-        // 재고 확보 실패
-        if (updated == 0) {
-            log.info("재고 확보에 실패했습니다 userId : {}, bidId : {}, quantity : {}",
-                command.getUserId(), command.getBidId(), command.getQuantity());
-            return BidResponse.fail(
+            if (winner != null) {
+                log.info("이미 처리된 작업입니다. userId : {}, bidId : {} idempotencyKey : {}",
+                    command.getUserId(), command.getBidId(), command.getIdempotencyKey());
+
+                stockRedisService.rollback(
+                    command.getBidId(),
+                    allocationKey.toString(),
+                    command.getIdempotencyKey().toString(),
+                    command.getQuantity()
+                );
+
+                return BidResponse.success(
+                    winner.getBidId(),
+                    winner.getQuantity(),
+                    winner.getAllocationKey(),
+                    winner.getExpireAt()
+                );
+            }
+
+            // 비관락
+            BidCompetition bid = bidCompetitionRepository.findByIdForUpdate(command.getBidId());
+
+            // 경쟁 상태 점검
+            if (bid.isNotAvailable() || bid.isEnd(now)) {
+                log.info("판매 경쟁이 종료되었습니다.");
+
+                stockRedisService.rollback(
+                    command.getBidId(),
+                    allocationKey.toString(),
+                    command.getIdempotencyKey().toString(),
+                    command.getQuantity()
+                );
+
+                return BidResponse.fail(
+                    command.getBidId(),
+                    command.getQuantity(),
+                    "판매 경쟁이 종료되어 주문을 받을 수 없습니다."
+                );
+            }
+
+            // 재고 확인 및 확보
+            int updated = bidCompetitionRepository.decreaseStock(
                 command.getBidId(),
+                command.getQuantity(),
+                now
+            );
+
+            // 재고 확보 실패
+            if (updated == 0) {
+                log.info("재고 확보에 실패했습니다 userId : {}, bidId : {}, quantity : {}",
+                    command.getUserId(), command.getBidId(), command.getQuantity());
+
+                stockRedisService.rollback(
+                    command.getBidId(),
+                    allocationKey.toString(),
+                    command.getIdempotencyKey().toString(),
+                    command.getQuantity()
+                );
+
+                return BidResponse.fail(
+                    command.getBidId(),
+                    command.getQuantity(),
+                    "재고 확보에 실패했습니다."
+                );
+            }
+
+            Winner newWinner = Winner.create(
+                command.getUserId(),
+                bid.getId(),
                 bid.getProductId(),
                 command.getQuantity(),
-                "재고 확보에 실패했습니다."
+                allocationKey,
+                command.getIdempotencyKey(),
+                now,
+                expireAt
             );
-        }
 
-        log.info("expiredAt : {}", expireAt);
+            // Winner 등록
+            Winner savedWinner = winnerRepository.save(newWinner);
 
-        UUID allocationKey = UUID.randomUUID();
-        Winner newWinner = Winner.create(
-            command.getUserId(),
-            bid.getId(),
-            bid.getProductId(),
-            command.getQuantity(),
-            allocationKey,
-            command.getIdempotencyKey(),
-            now,
-            expireAt
-        );
-
-        // Winner 등록
-        Winner savedWinner = winnerRepository.save(newWinner);
-
-        WinnerCreatedEvent event = WinnerCreatedEvent.of(
-            command.getUserId(),
-            bid.getProductId(),
-            bid.getProductPrice().intValue(), // FIXME: 나중에 수정해야 함
-            command.getQuantity(),
-            bid.getCategoryId(),
-            bid.getSellerId(),
-            allocationKey,
-            expireAt,
-            command.getStreet(),
-            command.getCity(),
-            command.getZipcode()
-        );
-
-        String idempotencyKey = InventoryChangeType.RESERVE.idempotencyKey(
-            String.valueOf(allocationKey)
-        );
-
-        Integer delta = command.getQuantity();
-
-        Integer stockBefore = bid.getStock();
-        Integer stockAfter = stockBefore - delta;
-
-        BidInventoryLog log = BidInventoryLog.create(
-            bid.getId(),
-            savedWinner.getId(),
-            InventoryChangeType.RESERVE,
-            stockBefore,
-            stockAfter,
-            delta,
-            idempotencyKey,
-            now
-        );
-
-        bidInventoryLogRepository.saveAndFlush(log);
-
-        Outbox outbox = Outbox.create(
-            AggregateType.BID,
-            bid.getId(),
-            EventType.BID_WINNER_SELECTED,
-            UUID.randomUUID(),
-            makePayload(event)
-        );
-
-        if (tracer.currentSpan() != null) {
-            outbox.attachTracing(
-                tracer.currentSpan().context().traceId(),
-                tracer.currentSpan().context().spanId()
+            WinnerCreatedEvent event = WinnerCreatedEvent.of(
+                command.getUserId(),
+                bid.getProductId(),
+                bid.getProductPrice().intValue(),
+                command.getQuantity(),
+                bid.getCategoryId(),
+                bid.getSellerId(),
+                allocationKey,
+                expireAt,
+                command.getStreet(),
+                command.getCity(),
+                command.getZipcode()
             );
+
+            String idempotencyKey = InventoryChangeType.RESERVE.idempotencyKey(
+                String.valueOf(allocationKey)
+            );
+
+            Integer delta = command.getQuantity();
+
+            Integer stockBefore = bid.getStock();
+            Integer stockAfter = stockBefore - delta;
+
+            BidInventoryLog log = BidInventoryLog.create(
+                bid.getId(),
+                savedWinner.getId(),
+                InventoryChangeType.RESERVE,
+                stockBefore,
+                stockAfter,
+                delta,
+                idempotencyKey,
+                now
+            );
+
+            bidInventoryLogRepository.saveAndFlush(log);
+
+            Outbox outbox = Outbox.create(
+                AggregateType.BID,
+                bid.getId(),
+                EventType.BID_WINNER_SELECTED,
+                UUID.randomUUID(),
+                makePayload(event)
+            );
+
+            if (tracer.currentSpan() != null) {
+                outbox.attachTracing(
+                    tracer.currentSpan().context().traceId(),
+                    tracer.currentSpan().context().spanId()
+                );
+            }
+
+            outboxRepository.save(outbox);
+
+            return BidResponse.success(
+                savedWinner.getBidId(),
+                savedWinner.getQuantity(),
+                savedWinner.getAllocationKey(),
+                savedWinner.getExpireAt()
+            );
+        } catch (Exception e) {
+
+            stockRedisService.rollback(
+                command.getBidId(),
+                allocationKey.toString(),
+                command.getIdempotencyKey().toString(),
+                command.getQuantity()
+            );
+
+            throw e;
         }
-
-
-
-        // Winner가 등록된 후, 등록되었음을 알리는 이벤트 발행
-        outboxRepository.save(outbox);
-
-        return BidResponse.success(
-            savedWinner.getBidId(),
-            savedWinner.getProductId(),
-            savedWinner.getQuantity(),
-            savedWinner.getAllocationKey(),
-            savedWinner.getExpireAt()
-        );
 
     }
 
@@ -305,6 +418,12 @@ public class BidCompetitionService {
             throw new WinnerConflictException(BidErrorCode.WINNER_CONFLICT);
         }
 
+        stockRedisService.confirmCleanup(
+            winner.getBidId(),
+            winner.getAllocationKey().toString(),
+            winner.getIdempotencyKey().toString()
+        );
+
         return ServiceResult.SUCCESS;
     }
 
@@ -374,6 +493,13 @@ public class BidCompetitionService {
             log.error("예기치 못한 예외로 인해 처리하지 못했습니다. allocationKey : {}", command.getAllocationKey());
             throw new WinnerConflictException(BidErrorCode.WINNER_CONFLICT);
         }
+
+        stockRedisService.rollback(
+            winner.getBidId(),
+            winner.getAllocationKey().toString(),
+            winner.getIdempotencyKey().toString(),
+            winner.getQuantity()
+        );
     }
 
     @Transactional
@@ -480,6 +606,13 @@ public class BidCompetitionService {
                 throw new WinnerConflictException(BidErrorCode.WINNER_CONFLICT);
             }
         }
+
+        stockRedisService.rollback(
+            winner.getBidId(),
+            winner.getAllocationKey().toString(),
+            winner.getIdempotencyKey().toString(),
+            delta
+        );
     }
 
     // TODO: 나중에 클래스로 분리할 예정

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidCompetitionService.java
@@ -607,12 +607,19 @@ public class BidCompetitionService {
             }
         }
 
-        stockRedisService.rollback(
+
+        long restored = stockRedisService.refundRestore(
             winner.getBidId(),
-            winner.getAllocationKey().toString(),
-            winner.getIdempotencyKey().toString(),
+            command.getRefundId(),
             delta
         );
+        if (restored == 0) {
+            log.info("이미 처리된 환불 복구입니다. bidId={}, refundId={}", winner.getBidId(),
+                command.getRefundId());
+        } else if (restored < 0) {
+            log.error("환불 복구 실패(redis) bidId={}, refundId={}, result={}", winner.getBidId(),
+                command.getRefundId(), restored);
+        }
     }
 
     // TODO: 나중에 클래스로 분리할 예정

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidProcessor.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidProcessor.java
@@ -10,6 +10,7 @@ import com.smore.bidcompetition.domain.model.BidInventoryLog;
 import com.smore.bidcompetition.domain.model.Winner;
 import com.smore.bidcompetition.domain.status.InventoryChangeType;
 import com.smore.bidcompetition.infrastructure.error.BidErrorCode;
+import com.smore.bidcompetition.infrastructure.redis.StockRedisService;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -37,6 +38,7 @@ public class BidProcessor {
 
     private final BidCompetitionRepository bidCompetitionRepository;
     private final BidInventoryLogRepository bidInventoryLogRepository;
+    private final StockRedisService stockRedisService;
     private final WinnerRepository winnerRepository;
     private final BidEndFinalizer bidEndFinalizer;
     private final Clock clock;
@@ -174,6 +176,13 @@ public class BidProcessor {
                 winner.getId(), winner.getBidId());
             throw new BidConflictException(BidErrorCode.BID_CONFLICT);
         }
+
+        stockRedisService.rollback(
+            winner.getBidId(),
+            winner.getAllocationKey().toString(),
+            winner.getIdempotencyKey().toString(),
+            winner.getQuantity()
+        );
     }
 
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/model/BidCompetition.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/model/BidCompetition.java
@@ -106,12 +106,12 @@ public class BidCompetition {
             .build();
     }
 
-    public boolean isExpired(LocalDateTime now) {
+    public boolean isEnd(LocalDateTime now) {
         return this.endAt.isBefore(now);
     }
 
-    public boolean isNotActive() {
-        return this.bidStatus != BidStatus.ACTIVE;
+    public boolean isNotAvailable() {
+        return this.bidStatus != BidStatus.ACTIVE && this.bidStatus != BidStatus.CLOSED;
     }
 
     public boolean isEnd() {

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/AsyncConfig.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/AsyncConfig.java
@@ -14,11 +14,13 @@ public class AsyncConfig {
     public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(100);
-        executor.setQueueCapacity(50);
+        executor.setCorePoolSize(60);
+        executor.setMaxPoolSize(60);
+        executor.setQueueCapacity(200);
         executor.setThreadNamePrefix("task-worker");
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
+        executor.setPrestartAllCoreThreads(true);
 
         return executor;
     }
@@ -41,7 +43,7 @@ public class AsyncConfig {
 
         executor.setCorePoolSize(10);
         executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(50);
+        executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("winner-task");
         executor.initialize();
         return executor;

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/KafkaConfig.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/KafkaConfig.java
@@ -24,7 +24,7 @@ public class KafkaConfig {
     @Bean
     public NewTopic bidWinnerConfirmTopic() {
         return TopicBuilder.name(bidWinnerConfirm)
-            .partitions(3)
+            .partitions(5)
             .replicas(3)
             .build();
     }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/RedisLuaConfig.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/RedisLuaConfig.java
@@ -1,0 +1,41 @@
+package com.smore.bidcompetition.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+
+@Configuration
+public class RedisLuaConfig {
+    @Bean
+    public DefaultRedisScript<Long> reserveStockScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("redis/lua/reserve_stock.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> rollbackRestoreScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("redis/lua/rollback_restore.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> confirmCleanupScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("redis/lua/confirm_cleanup.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> setStockScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("redis/lua/setting_stock.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/RedisLuaConfig.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/config/RedisLuaConfig.java
@@ -38,4 +38,12 @@ public class RedisLuaConfig {
         script.setResultType(Long.class);
         return script;
     }
+
+    @Bean
+    public DefaultRedisScript<Long> refundRestoreScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("redis/lua/refund_restore.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/entity/WinnerEntity.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/entity/WinnerEntity.java
@@ -32,7 +32,7 @@ import lombok.NoArgsConstructor;
         ),
         @UniqueConstraint(
             name = "uk_winner_idempotency_key",
-            columnNames = {"idempotency_key"}
+            columnNames = {"bid_id", "idempotency_key"}
         )
     }
 )

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustom.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface WinnerJpaRepositoryCustom {
 
-    WinnerEntity findByIdempotencyKey(UUID idempotencyKey);
+    WinnerEntity findByIdempotencyKey(UUID bidId, UUID idempotencyKey);
 
     WinnerEntity findByAllocationKey(UUID allocationKey);
 

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustomImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerJpaRepositoryCustomImpl.java
@@ -25,12 +25,13 @@ public class WinnerJpaRepositoryCustomImpl implements WinnerJpaRepositoryCustom{
     private final EntityManager em;
 
     @Override
-    public WinnerEntity findByIdempotencyKey(UUID idempotencyKey) {
+    public WinnerEntity findByIdempotencyKey(UUID bidId, UUID idempotencyKey) {
 
         return queryFactory
             .select(winnerEntity)
             .from(winnerEntity)
             .where(
+                winnerEntity.bidId.eq(bidId),
                 winnerEntity.idempotencyKey.eq(idempotencyKey)
             )
             .fetchOne();

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/winner/WinnerRepositoryImpl.java
@@ -34,9 +34,9 @@ public class WinnerRepositoryImpl implements WinnerRepository {
     }
 
     @Override
-    public Winner findByIdempotencyKey(UUID idempotencyKey) {
+    public Winner findByIdempotencyKey(UUID bidId, UUID idempotencyKey) {
 
-        WinnerEntity entity = winnerJpaRepository.findByIdempotencyKey(idempotencyKey);
+        WinnerEntity entity = winnerJpaRepository.findByIdempotencyKey(bidId, idempotencyKey);
 
         if (entity == null) return null;
 

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisArgs.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisArgs.java
@@ -1,0 +1,42 @@
+package com.smore.bidcompetition.infrastructure.redis;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class StockRedisArgs {
+
+    // Object[] 타입을 반환하는 이유는 RedisTemplate.execute()의 시그니처를 맞추기 위함
+    public Object[] reserveArgs(String userId, int quantity, long winnerTtlSeconds, long idemTtlSeconds) {
+        if (userId == null || userId.isBlank()) {
+            throw new IllegalArgumentException("userId는 필수값입니다.");
+        }
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("quantity는 1 이상이어야 합니다.");
+        }
+        if (winnerTtlSeconds <= 0) {
+            throw new IllegalArgumentException("winnerTtlSeconds는 1 이상이어야 합니다.");
+        }
+        if (idemTtlSeconds <= 0) {
+            throw new IllegalArgumentException("idemTtlSeconds는 1 이상이어야 합니다.");
+        }
+
+        return new Object[] {
+            userId,
+            String.valueOf(quantity),
+            String.valueOf(winnerTtlSeconds),
+            String.valueOf(idemTtlSeconds)
+        };
+    }
+
+    public Object[] rollbackArgs(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("quantity는 1 이상이어야 합니다.");
+        }
+        return new Object[] { String.valueOf(quantity) };
+    }
+
+    public Object[] confirmArgs() {
+        return new Object[0];
+    }
+
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisKeys.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisKeys.java
@@ -9,6 +9,7 @@ public class StockRedisKeys {
     private static final String STOCK_PREFIX = "stock";
     private static final String WINNER_PREFIX = "winner";
     private static final String IDEM_PREFIX = "idem";
+    private static final String REFUND_PREFIX = "refund";
 
 
     public String stockKey(UUID bidId) {
@@ -26,5 +27,11 @@ public class StockRedisKeys {
         if (bidId == null) throw new IllegalArgumentException("bidId는 필수값입니다.");
         if (idempotencyKey == null) throw new IllegalArgumentException("idempotencyKey는 필수값입니다.");
         return IDEM_PREFIX + ":{" + bidId + "}:" + idempotencyKey;
+    }
+
+    public String refundKey(UUID bidId, UUID refundId) {
+        if (bidId == null) throw new IllegalArgumentException("bidId는 필수값입니다.");
+        if (refundId == null) throw new IllegalArgumentException("refundId는 필수값입니다.");
+        return REFUND_PREFIX + ":{" + bidId + "}:" + refundId;
     }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisKeys.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisKeys.java
@@ -1,0 +1,30 @@
+package com.smore.bidcompetition.infrastructure.redis;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StockRedisKeys {
+
+    private static final String STOCK_PREFIX = "stock";
+    private static final String WINNER_PREFIX = "winner";
+    private static final String IDEM_PREFIX = "idem";
+
+
+    public String stockKey(UUID bidId) {
+        if (bidId == null) throw new IllegalArgumentException("bidId는 필수값입니다.");
+        return STOCK_PREFIX + ":{" + bidId + "}";
+    }
+
+    public String winnerKey(UUID bidId, String allocationKey) {
+        if (bidId == null) throw new IllegalArgumentException("bidId는 필수값입니다.");
+        if (allocationKey == null) throw new IllegalArgumentException("allocationKey는 필수값입니다.");
+        return WINNER_PREFIX + ":{" + bidId + "}:" + allocationKey;
+    }
+
+    public String idemKey(UUID bidId, String idempotencyKey) {
+        if (bidId == null) throw new IllegalArgumentException("bidId는 필수값입니다.");
+        if (idempotencyKey == null) throw new IllegalArgumentException("idempotencyKey는 필수값입니다.");
+        return IDEM_PREFIX + ":{" + bidId + "}:" + idempotencyKey;
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisService.java
@@ -14,6 +14,7 @@ public class StockRedisService {
     private final StringRedisTemplate redis;
     private final DefaultRedisScript<Long> reserveStockScript;
     private final DefaultRedisScript<Long> rollbackRestoreScript;
+    private final DefaultRedisScript<Long> refundRestoreScript;
     private final DefaultRedisScript<Long> confirmCleanupScript;
     private final DefaultRedisScript<Long> setStockScript;
     private final StockRedisKeys keys;
@@ -40,6 +41,17 @@ public class StockRedisService {
                 keys.stockKey(bidId),
                 keys.winnerKey(bidId, allocationKey),
                 keys.idemKey(bidId, idemKey)
+            ),
+            args.rollbackArgs(quantity)
+        );
+    }
+
+    public long refundRestore(UUID bidId, UUID refundId, int quantity) {
+        return redis.execute(
+            refundRestoreScript,
+            List.of(
+                keys.stockKey(bidId),
+                keys.refundKey(bidId, refundId)
             ),
             args.rollbackArgs(quantity)
         );

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisService.java
@@ -1,0 +1,65 @@
+package com.smore.bidcompetition.infrastructure.redis;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockRedisService {
+
+    private final StringRedisTemplate redis;
+    private final DefaultRedisScript<Long> reserveStockScript;
+    private final DefaultRedisScript<Long> rollbackRestoreScript;
+    private final DefaultRedisScript<Long> confirmCleanupScript;
+    private final DefaultRedisScript<Long> setStockScript;
+    private final StockRedisKeys keys;
+    private final StockRedisArgs args;
+
+    public long reserve(UUID bidId, String allocationKey, String idemKey, String userId,
+        int quantity, long ttl) {
+
+        return redis.execute(
+            reserveStockScript,
+            List.of(
+                keys.stockKey(bidId),
+                keys.winnerKey(bidId, allocationKey),
+                keys.idemKey(bidId, idemKey)
+            ),
+            args.reserveArgs(userId, quantity, ttl, ttl)
+        );
+    }
+
+    public long rollback(UUID bidId, String allocationKey, String idemKey, int quantity) {
+        return redis.execute(
+            rollbackRestoreScript,
+            List.of(
+                keys.stockKey(bidId),
+                keys.winnerKey(bidId, allocationKey),
+                keys.idemKey(bidId, idemKey)
+            ),
+            args.rollbackArgs(quantity)
+        );
+    }
+
+    public void confirmCleanup(UUID bidId, String allocationKey, String idemKey) {
+        redis.execute(
+            confirmCleanupScript,
+            List.of(
+                keys.winnerKey(bidId, allocationKey),
+                keys.idemKey(bidId, idemKey)
+            )
+        );
+    }
+
+    public long setStock(UUID bidId, int stockQuantity) {
+        return redis.execute(
+            setStockScript,
+            List.of(keys.stockKey(bidId)),
+            String.valueOf(stockQuantity)
+        );
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/dto/BidResponse.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/dto/BidResponse.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BidResponse {
     private UUID bidId;
-    private UUID productId;
     private Integer quantity;
     private UUID allocationKey;
     private String expireAt;
@@ -20,14 +19,12 @@ public class BidResponse {
 
     public static BidResponse success(
         UUID bidId,
-        UUID productId,
         Integer quantity,
         UUID allocationKey,
         LocalDateTime expireAt
     ) {
         return BidResponse.builder()
             .bidId(bidId)
-            .productId(productId)
             .quantity(quantity)
             .allocationKey(allocationKey)
             .expireAt(expireAt.toString())
@@ -37,14 +34,26 @@ public class BidResponse {
 
     public static BidResponse fail(
         UUID bidId,
-        UUID productId,
         Integer quantity,
         String message
     ) {
         return BidResponse.builder()
             .bidId(bidId)
-            .productId(productId)
             .quantity(quantity)
+            .message(message)
+            .build();
+    }
+
+    public static BidResponse processing(
+        UUID bidId,
+        Integer quantity,
+        UUID allocationKey,
+        String message
+    ) {
+        return BidResponse.builder()
+            .bidId(bidId)
+            .quantity(quantity)
+            .allocationKey(allocationKey)
             .message(message)
             .build();
     }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/BidScheduler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/BidScheduler.java
@@ -27,10 +27,10 @@ public class BidScheduler {
 
     // TODO: 페이지 스킵 발생하므로 이를 해결해야 함
     // TODO: @Async 비동기 예외 모니터링/재시도 처리 추가
-    @Scheduled(fixedDelay = 30_000)
+    @Scheduled(fixedDelay = 10_000)
     public void recoveryExpiredStockScheduler() {
         int page = 0;
-        int pageSize = 100;
+        int pageSize = 50;
 
         while (true) {
             Page<UUID> taskIds = bidProcessor.getExpiredWinnerIds(

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/OutboxScheduler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/OutboxScheduler.java
@@ -24,10 +24,10 @@ public class OutboxScheduler {
         EventStatus.PENDING
     );
 
-    @Scheduled(fixedDelay = 10000)
+    @Scheduled(fixedDelay = 1000)
     public void outboxTasks() {
         int page = 0;
-        int pageSize = 100;
+        int pageSize = 50;
 
         while (true) {
             Page<Long> taskIds = outboxRepository.findPendingIds(

--- a/bidcompetition/src/main/resources/application-dev.yml
+++ b/bidcompetition/src/main/resources/application-dev.yml
@@ -25,6 +25,12 @@ spring:
   kafka:
     bootstrap-servers: kafka-1:9092,kafka-2:9092,kafka-3:9092
 
+  data:
+    redis:
+      host: redis-stack
+      port: 6379
+      timeout: 10s
+
 eureka:
   client:
     service-url:
@@ -44,7 +50,7 @@ management:
         include: health,info,prometheus
   tracing:
     sampling:
-      probability: 1.0
+      probability: 0.1
   zipkin:
     tracing:
       endpoint: http://zipkin:9411/api/v2/spans

--- a/bidcompetition/src/main/resources/application-local.yml
+++ b/bidcompetition/src/main/resources/application-local.yml
@@ -24,6 +24,12 @@ spring:
   kafka:
     bootstrap-servers: localhost:19092,localhost:29092,localhost:39092
 
+  data:
+    redis:
+      host: redis-bid
+      port: 6379
+      timeout: 2s
+
 eureka:
   client:
     service-url:

--- a/bidcompetition/src/main/resources/application-prod.yml
+++ b/bidcompetition/src/main/resources/application-prod.yml
@@ -1,0 +1,75 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  sql:
+    init:
+      mode: always
+
+  datasource:
+    url: jdbc:postgresql://${RDS_END_POINT}/bid
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+    defer-datasource-initialization: true
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: AWS_MSK_IAM
+      sasl.jaas.config: software.amazon.msk.auth.iam.IAMLoginModule required;
+      sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 10
+      properties:
+        enable.idempotence: true
+
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      group-id: order-service-consumer-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+
+    listener:
+      ack-mode: manual
+      observation-enabled: true
+
+  data:
+    redis:
+      url: ${ELASTIC_CACHE_ADDR}
+      timeout: 2s
+      repositories:
+        enabled: false
+
+eureka:
+  client:
+    enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  tracing:
+    sampling:
+      probability: 1.0
+
+  zipkin:
+    tracing:
+      endpoint: http://zipkin:9411/api/v2/spans

--- a/bidcompetition/src/main/resources/redis/lua/confirm_cleanup.lua
+++ b/bidcompetition/src/main/resources/redis/lua/confirm_cleanup.lua
@@ -1,0 +1,7 @@
+-- KEYS[1] = winner:{bidId}:{allocationKey}
+-- KEYS[2] = idem:{bidId}:{idempotencyKey}
+-- return 1 always (idempotent)
+
+redis.call('DEL', KEYS[1])
+redis.call('DEL', KEYS[2])
+return 1

--- a/bidcompetition/src/main/resources/redis/lua/refund_restore.lua
+++ b/bidcompetition/src/main/resources/redis/lua/refund_restore.lua
@@ -1,0 +1,24 @@
+-- 환불 시 재고 복구 (winner/idempotency 키가 이미 정리된 경우용)
+-- KEYS[1] = stock:{bidId}
+-- KEYS[2] = refund:{bidId}:{refundId} (idempotency)
+-- ARGV[1] = quantity
+--
+-- return:
+--  1 restored
+--  0 already restored (idempotent)
+-- -3 invalid args
+
+local quantity = tonumber(ARGV[1])
+if (not quantity) or quantity <= 0 then
+  return -3
+end
+
+-- 이미 복구된 환불이면 재실행 방지
+if redis.call('EXISTS', KEYS[2]) == 1 then
+  return 0
+end
+
+redis.call('INCRBY', KEYS[1], quantity)
+redis.call('SET', KEYS[2], '1', 'EX', 60 * 60 * 24) -- 1 day TTL for traceability
+
+return 1

--- a/bidcompetition/src/main/resources/redis/lua/reserve_stock.lua
+++ b/bidcompetition/src/main/resources/redis/lua/reserve_stock.lua
@@ -1,0 +1,42 @@
+-- KEYS[1] = stock:{bidId}
+-- KEYS[2] = winner:{bidId}:{allocationKey}
+-- KEYS[3] = idem:{bidId}:{idempotencyKey}
+--
+-- ARGV[1] = userId
+-- ARGV[2] = quantity
+-- ARGV[3] = winnerTtlSeconds
+-- ARGV[4] = idemTtlSeconds
+
+--
+-- return:
+--  1  success
+--  0  insufficient / invalid
+-- -2 duplicate (idem)
+
+if redis.call('EXISTS', KEYS[3]) == 1 then
+  return -2
+end
+
+local stockStr = redis.call('GET', KEYS[1])
+if not stockStr then
+  return 0
+end
+
+local stock = tonumber(stockStr)
+local quantity = tonumber(ARGV[2])
+local winnerTtlSeconds = tonumber(ARGV[3])
+local idemTtlSeconds = tonumber(ARGV[4])
+
+if (not stock) or (not quantity) or quantity <= 0 or (not winnerTtlSeconds) or winnerTtlSeconds <= 0 or (not idemTtlSeconds) or idemTtlSeconds <= 0 then
+  return 0
+end
+
+if stock < quantity then
+  return 0
+end
+
+redis.call('DECRBY', KEYS[1], quantity)
+redis.call('SET', KEYS[2], ARGV[1], 'EX', winnerTtlSeconds)
+redis.call('SET', KEYS[3], '1', 'EX', idemTtlSeconds)
+
+return 1

--- a/bidcompetition/src/main/resources/redis/lua/rollback_restore.lua
+++ b/bidcompetition/src/main/resources/redis/lua/rollback_restore.lua
@@ -1,0 +1,23 @@
+-- KEYS[1] = stock:{bidId}
+-- KEYS[2] = winner:{bidId}:{allocationKey}
+-- KEYS[3] = idem:{bidId}:{idempotencyKey}
+-- ARGV[1] = quantity
+--
+-- return:
+--  1 rolled back
+--  0 nothing to rollback (already done / no hold)
+-- -3 invalid args
+
+local quantity = tonumber(ARGV[1])
+if (not quantity) or quantity <= 0 then
+  return -3
+end
+
+-- winner가 있을 때만 재고 복구 (중복복구 방지)
+if redis.call('DEL', KEYS[2]) == 1 then
+  redis.call('INCRBY', KEYS[1], quantity)
+  redis.call('DEL', KEYS[3]) -- 실패면 재시도 허용(권장)
+  return 1
+end
+
+return 0

--- a/bidcompetition/src/main/resources/redis/lua/setting_stock.lua
+++ b/bidcompetition/src/main/resources/redis/lua/setting_stock.lua
@@ -1,0 +1,14 @@
+-- KEYS[1] = stock:{bidId}
+-- ARGV[1] = stockQuantity
+
+local stock = tonumber(ARGV[1])
+if not stock or stock < 0 then
+  return -1
+end
+
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  return 0
+end
+
+redis.call('SET', KEYS[1], stock)
+return stock

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     // prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // MSK 설치
+    implementation 'software.amazon.msk:aws-msk-iam-auth:2.2.0'
+
 }
 
 dependencyManagement {

--- a/order/src/main/resources/application-prod.yml
+++ b/order/src/main/resources/application-prod.yml
@@ -1,0 +1,64 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  sql:
+    init:
+      mode: always
+
+  datasource:
+    url: jdbc:postgresql://${RDS_END_POINT}/d_order
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: AWS_MSK_IAM
+      sasl.jaas.config: software.amazon.msk.auth.iam.IAMLoginModule required;
+      sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 10
+      properties:
+        enable.idempotence: true
+
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      group-id: order-service-consumer-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+
+    listener:
+      ack-mode: manual
+      observation-enabled: true
+
+eureka:
+  client:
+    enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  tracing:
+    sampling:
+      probability: 1.0


### PR DESCRIPTION
### 요약 
- `Redis`와 `LuaScript`를 이용하여 부하 분산 구현 
- 요청이 들어오면 우선 레디스에서 원자적으로 재고를 확인하고 재고를 감소하는 로직이 실행된다.
- 정상적으로 통과되었다면 실제 재고 확보를 위해 기존 DB 재고 로직이 수행된다.

### 시퀀스 다이어그램
<img width="955" height="2114" alt="image" src="https://github.com/user-attachments/assets/9b701372-d5ad-4a75-a9f6-cd7d749d38f6" />

### Redis 기반 재고 및 부하 분산 흐름 정리
1. **Redis 재고 선점 (Traffic Filtering)**
요청이 들어오면 DB에 접근하기 전, Redis의 reserve 메서드를 통해 재고 확보를 먼저 시도합니다.
Redis는 싱글 스레드 기반으로 원자적(Atomic) 연산을 수행하므로, 재고가 소진된 경우 DB 트랜잭션까지 진입하지 않고 즉시 요청을 거절합니다.
이를 통해 불필요한 DB 커넥션 점유와 락 대기 시간을 획기적으로 감소시켰습니다.
2. **멱등성 검증 (Idempotency Check)**
Redis 선점에 성공했더라도, 네트워크 지연이나 재시도 로직에 의해 이미 처리된 요청일 수 있습니다.
DB 트랜잭션 내부에서 Winner 테이블을 조회하여 동일한 `idempotencyKey`로 처리된 내역이 있는지 확인합니다.
이미 처리된 요청이라면 Redis 선점 내역을 롤백(Rollback)하고, 기존 처리 결과를 반환하여 데이터 일관성을 유지합니다.
3. **DB 트랜잭션 및 정합성 보장 (Consistency)**
Redis와 멱등성 검증을 통과한 유효한 요청에 대해서만 DB의 비관적 락(findByIdForUpdate)을 획득합니다.
실제 재고 차감(decreaseStock)과 당첨자 생성(Winner), 로그 기록(BidInventoryLog)을 하나의 트랜잭션으로 묶어 최종적인 데이터 정합성을 보장합니다.
4. **예외 처리 및 보상 트랜잭션 (Compensating Transaction)**
DB 트랜잭션 수행 중 예외가 발생하거나 비즈니스 로직(예: 판매 종료)에 의해 실패하는 경우, `stockRedisService.rollback`을 호출합니다.
선점했던 Redis 재고를 다시 원복시켜 Redis와 DB 간의 재고 수량 불일치를 방지합니다.

### 기술적 선택 이유 
Redis와 Lua를 활용한 `첫 번째 이유는 높은 트래픽 환경에서 원자적으로 제어`할 수 있기 때문입니다.

선착순 이벤트는 순간적으로 엄청난 트래픽이 몰리게 되는데 이를 감당하기 위해 `디스크 기반의 MQ 보다는 인메모리 기반의 Redis가 적합하다고 
판단`했습니다. 또한 `단순 재고 차감 로직을 위해 MQ의 컨슈머를 별도로 구현하는 것은 과하다고 생각`했습니다. 
`대신 Lua Script를 활용하여 간단하게 원자적 연산을 수행`하고자 했습니다.

`두 번째 이유는 명확한 역할 분리를 통해 DB로 몰리는 부하를 구조적으로 분산할 수 있기 때문입니다.`

Redis는 재고의 최종 상태를 관리하지 않고 수 많은 요청 중 일부만 선별하는 진입 제어 역할을 수행합니다.

즉, `Redis는 높은 트래픽을 먼저 받아 여기서 통과된 요청만 DB로 전달`하고, `DB는 제한된 요청에 대해서만 최종 재고 검증하고 확정`합니다.

### 그 외 변경된 내용 
- 스레드 풀 고갈로 인해 비동기 작업 예외가 발생하는 문제 해결
  - pageSize를 50으로 불러오고, 스레드풀의 스레드 개수를 60으로 설정
  -` java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy()` 정책을 추가하여 스레드 풀이 고갈되면 작업을 수행하던 스레드가 다음 작업을 동기적으로 실행하고, 이후 다시 스레드 풀에 여유가 생기면 메인 스레드는 비동기 스레에 작업을 위임하는 방향으로 수행됨
  - 배포를 위한 `application-prod.yml` 추가 (`Bid`, `Order`) 