### PR TITLE
Fix : Outbox 개선 및 PROCESSING 상태 영구 고착 문제 해결 

### DIFF
--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/OutboxRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/OutboxRepository.java
@@ -2,7 +2,9 @@ package com.smore.bidcompetition.application.repository;
 
 import com.smore.bidcompetition.domain.status.EventStatus;
 import com.smore.bidcompetition.domain.model.Outbox;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +13,8 @@ public interface OutboxRepository {
     Outbox findById(Long outboxId);
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     Outbox save(Outbox outbox);
 
@@ -21,5 +25,7 @@ public interface OutboxRepository {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,13 +1,17 @@
 package com.smore.bidcompetition.infrastructure.persistence.repository.outbox;
 
 import com.smore.bidcompetition.domain.status.EventStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OutboxJpaRepositoryCustom {
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     int claim(Long outboxId, EventStatus eventStatus);
 
@@ -16,5 +20,7 @@ public interface OutboxJpaRepositoryCustom {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.smore.bidcompetition.domain.status.EventStatus;
 import com.smore.bidcompetition.infrastructure.persistence.entity.QOutboxEntity;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PENDING)
@@ -67,6 +69,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -85,6 +88,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
             .set(outboxEntity.retryCount, outboxEntity.retryCount.add(1))
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -102,6 +106,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING),

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -9,7 +9,9 @@ import com.smore.bidcompetition.infrastructure.persistence.entity.OutboxEntity;
 import com.smore.bidcompetition.infrastructure.persistence.exception.CreateOutboxFailException;
 import com.smore.bidcompetition.infrastructure.persistence.exception.NotFoundOutboxException;
 import com.smore.bidcompetition.infrastructure.persistence.mapper.OutboxMapper;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -53,6 +55,11 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.findPendingIds(states, pageable);
+    }
+
+    @Override
+    public List<Long> findExpiredProcessingIds(LocalDateTime expiredAt) {
+        return outboxJpaRepository.findExpiredProcessingIds(expiredAt);
     }
 
     @Override
@@ -124,5 +131,10 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.markFail(outboxId, eventStatus, maxRetryCount);
+    }
+
+    @Override
+    public int bulkResetExpiredProcessingToReady(List<Long> ids) {
+        return outboxJpaRepository.bulkResetExpiredProcessingToReady(ids);
     }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/OutboxScheduler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/OutboxScheduler.java
@@ -4,6 +4,8 @@ package com.smore.bidcompetition.presentation.scheduler;
 import com.smore.bidcompetition.application.repository.OutboxRepository;
 import com.smore.bidcompetition.application.service.OutboxProcessor;
 import com.smore.bidcompetition.domain.status.EventStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,5 +50,18 @@ public class OutboxScheduler {
             if (!taskIds.hasNext()) break;
             page++;
         }
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void recoverExpiredProcessing() {
+        LocalDateTime expiredAt = LocalDateTime.now().minusMinutes(2);
+
+        List<Long> expiredProcessingIds = outboxRepository.findExpiredProcessingIds(expiredAt);
+
+        if (expiredProcessingIds.isEmpty()) {
+            return;
+        }
+
+        int updated = outboxRepository.bulkResetExpiredProcessingToReady(expiredProcessingIds);
     }
 }

--- a/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
@@ -2,7 +2,9 @@ package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Outbox;
 import com.smore.order.domain.status.EventStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +13,8 @@ public interface OutboxRepository {
     Outbox findById(Long outboxId);
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     Outbox save(Outbox outbox);
 
@@ -21,5 +25,7 @@ public interface OutboxRepository {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,13 +1,17 @@
 package com.smore.order.infrastructure.persistence.repository.outbox;
 
 import com.smore.order.domain.status.EventStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OutboxJpaRepositoryCustom {
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     int claim(Long outboxId, EventStatus eventStatus);
 
@@ -16,5 +20,7 @@ public interface OutboxJpaRepositoryCustom {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import com.smore.order.domain.status.EventStatus;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PENDING)
@@ -67,6 +69,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -85,6 +88,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
             .set(outboxEntity.retryCount, outboxEntity.retryCount.add(1))
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -102,6 +106,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING),

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -8,7 +8,9 @@ import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOutboxFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOutboxException;
 import com.smore.order.infrastructure.persistence.mapper.OutboxMapper;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -52,6 +54,11 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.findPendingIds(states, pageable);
+    }
+
+    @Override
+    public List<Long> findExpiredProcessingIds(LocalDateTime expiredAt) {
+        return outboxJpaRepository.findExpiredProcessingIds(expiredAt);
     }
 
     @Override
@@ -123,5 +130,10 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.markFail(outboxId, eventStatus, maxRetryCount);
+    }
+
+    @Override
+    public int bulkResetExpiredProcessingToReady(List<Long> ids) {
+        return outboxJpaRepository.bulkResetExpiredProcessingToReady(ids);
     }
 }

--- a/order/src/main/java/com/smore/order/presentation/scheduler/OutboxScheduler.java
+++ b/order/src/main/java/com/smore/order/presentation/scheduler/OutboxScheduler.java
@@ -4,6 +4,8 @@ import com.smore.order.application.repository.OutboxRepository;
 import com.smore.order.application.service.OutboxProcessor;
 import com.smore.order.domain.status.EventStatus;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,5 +51,18 @@ public class OutboxScheduler {
             if (!taskIds.hasNext()) break;
             page++;
         }
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void recoverExpiredProcessing() {
+        LocalDateTime expiredAt = LocalDateTime.now().minusMinutes(2);
+
+        List<Long> expiredProcessingIds = outboxRepository.findExpiredProcessingIds(expiredAt);
+
+        if (expiredProcessingIds.isEmpty()) {
+            return;
+        }
+
+        int updated = outboxRepository.bulkResetExpiredProcessingToReady(expiredProcessingIds);
     }
 }


### PR DESCRIPTION
### 변경된 내용
- JPA Auditing이 update Bulk에 적용 안 되는 문제, 직접 SET 설정해줌으로써 해결 
- `PROCESSING` 상태이고 `claim` 된지 2분이 지난 경우, `PENDING` 상태로 되돌리는 스케줄러 추가 
  - 선점되어 `PROCESSING` 상태이지만 오류로 인해 영구 고착된 `row`를 찾아서 `PENDING` 상태로 복구시켜주는 스케줄러 추가 
  - `findExpiredProcessingIds()` 메서드 구현 
  - `bulkResetExpiredProcessingToReady()` 메서드 구현 

