### PR TITLE
Feat(Bid) : 레디스에 재고 등록 및 제거 할 때 발생할 수 있는 데이터 유실 방지를 위해 Outbox 패턴 적용 

### DIFF
--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/factory/OutboxHandlerFactory.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/factory/OutboxHandlerFactory.java
@@ -44,6 +44,7 @@ public class OutboxHandlerFactory {
             case BID_RESULT_FINALIZED -> new BidResultFinalizedHandler(tracer, propagator, bidResultFinalizedTopic, kafkaTemplate, outbox);
             case BID_INVENTORY_CONFIRM_TIMEOUT -> new InventoryConfirmTimeout(tracer, propagator, bidInventoryConfirmTimeoutTopic, kafkaTemplate, outbox);
             case SAVE_STOCK -> new SaveStockHandler(tracer, propagator, stockRedisService, outbox);
+            case DELETE_STOCK -> new ClearStockHandler(tracer, propagator, stockRedisService, outbox);
             default -> throw new IllegalArgumentException(
                 "지원되지 않은 이벤트입니다." + outbox.getEventType()
             );

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/factory/OutboxHandlerFactory.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/factory/OutboxHandlerFactory.java
@@ -1,11 +1,14 @@
 package com.smore.bidcompetition.application.factory;
 
 import com.smore.bidcompetition.application.handler.BidResultFinalizedHandler;
+import com.smore.bidcompetition.application.handler.ClearStockHandler;
 import com.smore.bidcompetition.application.handler.InventoryConfirmTimeout;
 import com.smore.bidcompetition.application.handler.ProductInventoryAdjustedHandler;
 import com.smore.bidcompetition.application.handler.OutboxHandler;
+import com.smore.bidcompetition.application.handler.SaveStockHandler;
 import com.smore.bidcompetition.application.handler.WinnerCreatedHandler;
 import com.smore.bidcompetition.domain.model.Outbox;
+import com.smore.bidcompetition.infrastructure.redis.StockRedisService;
 import io.micrometer.tracing.propagation.Propagator;
 import io.micrometer.tracing.Tracer;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ public class OutboxHandlerFactory {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final Tracer tracer;
     private final Propagator propagator;
+    private final StockRedisService stockRedisService;
 
     public OutboxHandler from(Outbox outbox) {
         return switch (outbox.getEventType()) {
@@ -39,6 +43,7 @@ public class OutboxHandlerFactory {
             case PRODUCT_INVENTORY_ADJUSTED -> new ProductInventoryAdjustedHandler(tracer, propagator, productInventoryAdjustedTopic, kafkaTemplate, outbox);
             case BID_RESULT_FINALIZED -> new BidResultFinalizedHandler(tracer, propagator, bidResultFinalizedTopic, kafkaTemplate, outbox);
             case BID_INVENTORY_CONFIRM_TIMEOUT -> new InventoryConfirmTimeout(tracer, propagator, bidInventoryConfirmTimeoutTopic, kafkaTemplate, outbox);
+            case SAVE_STOCK -> new SaveStockHandler(tracer, propagator, stockRedisService, outbox);
             default -> throw new IllegalArgumentException(
                 "지원되지 않은 이벤트입니다." + outbox.getEventType()
             );

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/handler/ClearStockHandler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/handler/ClearStockHandler.java
@@ -1,0 +1,66 @@
+package com.smore.bidcompetition.application.handler;
+
+import com.smore.bidcompetition.domain.model.Outbox;
+import com.smore.bidcompetition.domain.status.OutboxResult;
+import com.smore.bidcompetition.infrastructure.redis.StockRedisService;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "ClearStockHandler")
+public class ClearStockHandler implements OutboxHandler{
+
+    private final StockRedisService stockRedisService;
+    private final Outbox outbox;
+    private final Tracer tracer;
+    private final Propagator propagator;
+
+    public ClearStockHandler(Tracer tracer, Propagator propagator,
+        StockRedisService stockRedisService, Outbox outbox) {
+        this.tracer = tracer;
+        this.propagator = propagator;
+        this.stockRedisService = stockRedisService;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public OutboxResult execute() {
+
+        Span newSpan = restoreAndStartSpan();
+
+        try (Tracer.SpanInScope ws = tracer.withSpan(newSpan)) {
+            try {
+                boolean deleted = stockRedisService.deleteStock(outbox.getAggregateId());
+                if (!deleted) {
+                    log.info("stock 키가 없어 삭제할 게 없습니다. bidId={}", outbox.getAggregateId());
+                } else {
+                    log.info("stock 키 삭제 완료. bidId={}", outbox.getAggregateId());
+                }
+                return OutboxResult.SUCCESS;
+            } catch (Exception e) {
+                log.error("stock 키 삭제 중 예외. bidId={}", outbox.getAggregateId(), e);
+                return OutboxResult.FAIL;
+            }
+        } finally {
+            newSpan.end();
+        }
+    }
+
+    private Span restoreAndStartSpan() {
+        Span.Builder spanBuilder = propagator.extract(outbox, (carrier, key) -> {
+            if ("X-B3-TraceId".equalsIgnoreCase(key)) {
+                return carrier.getTraceId();
+            }
+            if ("X-B3-SpanId".equalsIgnoreCase(key)) {
+                return carrier.getSpanId();
+            }
+            return null;
+        });
+
+        Span newSpan = spanBuilder
+            .name("redis-clear-stock")
+            .start();
+        return newSpan;
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/handler/SaveStockHandler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/handler/SaveStockHandler.java
@@ -1,0 +1,70 @@
+package com.smore.bidcompetition.application.handler;
+
+import com.smore.bidcompetition.domain.model.Outbox;
+import com.smore.bidcompetition.domain.status.OutboxResult;
+import com.smore.bidcompetition.infrastructure.redis.StockRedisService;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "SaveStockHandler")
+public class SaveStockHandler implements OutboxHandler{
+
+    private final StockRedisService stockRedisService;
+    private final Outbox outbox;
+    private final Tracer tracer;
+    private final Propagator propagator;
+
+    public SaveStockHandler(Tracer tracer, Propagator propagator,
+        StockRedisService stockRedisService, Outbox outbox) {
+        this.tracer = tracer;
+        this.propagator = propagator;
+        this.stockRedisService = stockRedisService;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public OutboxResult execute() {
+
+        Span newSpan = restoreAndStartSpan();
+
+        try (Tracer.SpanInScope ws = tracer.withSpan(newSpan)) {
+            try {
+                long setResult = stockRedisService.setStock(outbox.getAggregateId(), Integer.parseInt(outbox.getPayload()));
+
+                if (setResult == -1L) {
+                    log.error("재고 초기화 실패: bidId={}, stock={}",outbox.getAggregateId(), Integer.parseInt(outbox.getPayload()));
+                    return OutboxResult.FAIL;
+                } else if (setResult == 0L) {
+                    log.info("이미 재고 키가 존재합니다. bidId={}", outbox.getAggregateId(), Integer.parseInt(outbox.getPayload()));
+                } else {
+                    log.info("재고 초기화 완료: bidId={}, stock={}", outbox.getAggregateId(), Integer.parseInt(outbox.getPayload()));
+                }
+            } catch (Exception e) {
+                log.error("재고 초기화 중 예외 발생. bidId={}", outbox.getAggregateId(), e);
+                return OutboxResult.FAIL;
+            }
+            return OutboxResult.SUCCESS;
+        } finally {
+            newSpan.end();
+        }
+    }
+
+    private Span restoreAndStartSpan() {
+        Span.Builder spanBuilder = propagator.extract(outbox, (carrier, key) -> {
+            if ("X-B3-TraceId".equalsIgnoreCase(key)) {
+                return carrier.getTraceId();
+            }
+            if ("X-B3-SpanId".equalsIgnoreCase(key)) {
+                return carrier.getSpanId();
+            }
+            return null;
+        });
+
+        Span newSpan = spanBuilder
+            .name("redis-saved-stock")
+            .start();
+        return newSpan;
+    }
+}

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/OutboxRepository.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/repository/OutboxRepository.java
@@ -2,7 +2,9 @@ package com.smore.bidcompetition.application.repository;
 
 import com.smore.bidcompetition.domain.status.EventStatus;
 import com.smore.bidcompetition.domain.model.Outbox;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +13,8 @@ public interface OutboxRepository {
     Outbox findById(Long outboxId);
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     Outbox save(Outbox outbox);
 
@@ -21,5 +25,7 @@ public interface OutboxRepository {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidEndFinalizer.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/application/service/BidEndFinalizer.java
@@ -76,6 +76,23 @@ public class BidEndFinalizer {
         }
 
         outboxRepository.save(outbox);
+
+        Outbox redisOutbox = Outbox.create(
+            AggregateType.BID,
+            bid.getId(),
+            EventType.DELETE_STOCK,
+            UUID.randomUUID(),
+            ""
+        );
+
+        if (tracer.currentSpan() != null) {
+            redisOutbox.attachTracing(
+                tracer.currentSpan().context().traceId(),
+                tracer.currentSpan().context().spanId()
+            );
+        }
+
+        outboxRepository.save(redisOutbox);
     }
 
     private String makePayload(BidEvent event)  {

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/EventType.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/domain/status/EventType.java
@@ -4,7 +4,9 @@ public enum EventType {
     BID_WINNER_SELECTED("경쟁 승리자 선정"),
     PRODUCT_INVENTORY_ADJUSTED("환불"),
     BID_RESULT_FINALIZED("경쟁 결과 최종 확정"),
-    BID_INVENTORY_CONFIRM_TIMEOUT("재고 확보 실패")
+    BID_INVENTORY_CONFIRM_TIMEOUT("재고 확보 실패"),
+    SAVE_STOCK("재고 저장"),
+    DELETE_STOCK("재고 클리어")
     ;
 
     private final String description;

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,13 +1,17 @@
 package com.smore.bidcompetition.infrastructure.persistence.repository.outbox;
 
 import com.smore.bidcompetition.domain.status.EventStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OutboxJpaRepositoryCustom {
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     int claim(Long outboxId, EventStatus eventStatus);
 
@@ -16,5 +20,7 @@ public interface OutboxJpaRepositoryCustom {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.smore.bidcompetition.domain.status.EventStatus;
 import com.smore.bidcompetition.infrastructure.persistence.entity.QOutboxEntity;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PENDING)
@@ -67,6 +69,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -85,6 +88,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
             .set(outboxEntity.retryCount, outboxEntity.retryCount.add(1))
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -102,6 +106,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING),

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -9,7 +9,9 @@ import com.smore.bidcompetition.infrastructure.persistence.entity.OutboxEntity;
 import com.smore.bidcompetition.infrastructure.persistence.exception.CreateOutboxFailException;
 import com.smore.bidcompetition.infrastructure.persistence.exception.NotFoundOutboxException;
 import com.smore.bidcompetition.infrastructure.persistence.mapper.OutboxMapper;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -53,6 +55,11 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.findPendingIds(states, pageable);
+    }
+
+    @Override
+    public List<Long> findExpiredProcessingIds(LocalDateTime expiredAt) {
+        return outboxJpaRepository.findExpiredProcessingIds(expiredAt);
     }
 
     @Override
@@ -124,5 +131,10 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.markFail(outboxId, eventStatus, maxRetryCount);
+    }
+
+    @Override
+    public int bulkResetExpiredProcessingToReady(List<Long> ids) {
+        return outboxJpaRepository.bulkResetExpiredProcessingToReady(ids);
     }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisService.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/infrastructure/redis/StockRedisService.java
@@ -74,4 +74,9 @@ public class StockRedisService {
             String.valueOf(stockQuantity)
         );
     }
+
+    public boolean deleteStock(UUID bidId) {
+        Boolean deleted = redis.delete(keys.stockKey(bidId));
+        return Boolean.TRUE.equals(deleted);
+    }
 }

--- a/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/OutboxScheduler.java
+++ b/bidcompetition/src/main/java/com/smore/bidcompetition/presentation/scheduler/OutboxScheduler.java
@@ -4,6 +4,8 @@ package com.smore.bidcompetition.presentation.scheduler;
 import com.smore.bidcompetition.application.repository.OutboxRepository;
 import com.smore.bidcompetition.application.service.OutboxProcessor;
 import com.smore.bidcompetition.domain.status.EventStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,5 +50,18 @@ public class OutboxScheduler {
             if (!taskIds.hasNext()) break;
             page++;
         }
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void recoverExpiredProcessing() {
+        LocalDateTime expiredAt = LocalDateTime.now().minusMinutes(2);
+
+        List<Long> expiredProcessingIds = outboxRepository.findExpiredProcessingIds(expiredAt);
+
+        if (expiredProcessingIds.isEmpty()) {
+            return;
+        }
+
+        int updated = outboxRepository.bulkResetExpiredProcessingToReady(expiredProcessingIds);
     }
 }

--- a/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
+++ b/order/src/main/java/com/smore/order/application/repository/OutboxRepository.java
@@ -2,7 +2,9 @@ package com.smore.order.application.repository;
 
 import com.smore.order.domain.model.Outbox;
 import com.smore.order.domain.status.EventStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +13,8 @@ public interface OutboxRepository {
     Outbox findById(Long outboxId);
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     Outbox save(Outbox outbox);
 
@@ -21,5 +25,7 @@ public interface OutboxRepository {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustom.java
@@ -1,13 +1,17 @@
 package com.smore.order.infrastructure.persistence.repository.outbox;
 
 import com.smore.order.domain.status.EventStatus;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OutboxJpaRepositoryCustom {
 
     Page<Long> findPendingIds(Collection<EventStatus> states, Pageable pageable);
+
+    List<Long> findExpiredProcessingIds(LocalDateTime expiredAt);
 
     int claim(Long outboxId, EventStatus eventStatus);
 
@@ -16,5 +20,7 @@ public interface OutboxJpaRepositoryCustom {
     int markRetry(Long outboxId, EventStatus eventStatus);
 
     int markFail(Long outboxId, EventStatus eventStatus, Integer maxRetryCount);
+
+    int bulkResetExpiredProcessingToReady(List<Long> ids);
 
 }

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxJpaRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import com.smore.order.domain.status.EventStatus;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PENDING)
@@ -67,6 +69,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -85,6 +88,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
             .set(outboxEntity.retryCount, outboxEntity.retryCount.add(1))
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING)
@@ -102,6 +106,7 @@ public class OutboxJpaRepositoryCustomImpl implements OutboxJpaRepositoryCustom 
         long updated = queryFactory
             .update(outboxEntity)
             .set(outboxEntity.eventStatus, eventStatus)
+            .set(outboxEntity.updatedAt, LocalDateTime.now())
             .where(
                 outboxEntity.id.eq(outboxId),
                 outboxEntity.eventStatus.eq(EventStatus.PROCESSING),

--- a/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
+++ b/order/src/main/java/com/smore/order/infrastructure/persistence/repository/outbox/OutboxRepositoryImpl.java
@@ -8,7 +8,9 @@ import com.smore.order.infrastructure.persistence.entity.outbox.OutboxEntity;
 import com.smore.order.infrastructure.persistence.exception.CreateOutboxFailException;
 import com.smore.order.infrastructure.persistence.exception.NotFoundOutboxException;
 import com.smore.order.infrastructure.persistence.mapper.OutboxMapper;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -52,6 +54,11 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.findPendingIds(states, pageable);
+    }
+
+    @Override
+    public List<Long> findExpiredProcessingIds(LocalDateTime expiredAt) {
+        return outboxJpaRepository.findExpiredProcessingIds(expiredAt);
     }
 
     @Override
@@ -123,5 +130,10 @@ public class OutboxRepositoryImpl implements OutboxRepository {
         }
 
         return outboxJpaRepository.markFail(outboxId, eventStatus, maxRetryCount);
+    }
+
+    @Override
+    public int bulkResetExpiredProcessingToReady(List<Long> ids) {
+        return outboxJpaRepository.bulkResetExpiredProcessingToReady(ids);
     }
 }

--- a/order/src/main/java/com/smore/order/presentation/scheduler/OutboxScheduler.java
+++ b/order/src/main/java/com/smore/order/presentation/scheduler/OutboxScheduler.java
@@ -4,6 +4,8 @@ import com.smore.order.application.repository.OutboxRepository;
 import com.smore.order.application.service.OutboxProcessor;
 import com.smore.order.domain.status.EventStatus;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,5 +51,18 @@ public class OutboxScheduler {
             if (!taskIds.hasNext()) break;
             page++;
         }
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void recoverExpiredProcessing() {
+        LocalDateTime expiredAt = LocalDateTime.now().minusMinutes(2);
+
+        List<Long> expiredProcessingIds = outboxRepository.findExpiredProcessingIds(expiredAt);
+
+        if (expiredProcessingIds.isEmpty()) {
+            return;
+        }
+
+        int updated = outboxRepository.bulkResetExpiredProcessingToReady(expiredProcessingIds);
     }
 }


### PR DESCRIPTION
### 변경 된 내용 
레디스에 재고 등록 및 제거 시 데이터 유실에 대한 대처가 없음 그러므로 Outbox를 사용하여 데이터 유실을 방지하고자 함 
- Bid가 생성된 후, 직접 `Redis`에 재고를 등록하던 로직을 `Outbox`에 등록하고, 이후 스케줄러에 의해 `Outbox`에서 꺼내서 Redis에 등록하도록 수정 
- `end()`로 인해 판매 경쟁이 종료되었을 때, `Redis`에서 관리되는 재고 정보를 제거하기 위한 레디스 명령을 `Outbox`에 등록하고, 이후 스케줄러에 의해 `Outbox`에서 꺼내어 `Redis`에서 제거하도록 수정 
- 레디스 등록 및 제거를 위한 `Outbox Handler` 클래스 추가 (`SaveStockHandler`, `ClearStockHandler`)
- `Outbox` 핸들러 클래스들을 `Factory` 클래스에 등록

### 참고사항
- 실시간 판매 경쟁할 때 레디스에 선착순 인원으로 선정되어 `Winner` 정보와 멱등 정보를 등록할 때는 `Outbox` 패턴을 사용하면 
DB 부하를 그대로 받게 되므로 이 경우는 `Outbox` 패턴이 아닌 다른 방식으로 해결함
